### PR TITLE
Moves dapperish from opentracing-go into basictracer

### DIFF
--- a/examples/dapperish.go
+++ b/examples/dapperish.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/opentracing/basictracer-go/examples/dapperish"
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+func client() {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		ctx, span := opentracing.BackgroundContextWithSpan(
+			opentracing.StartSpan("getInput"))
+		// Make sure that global trace tag propagation works.
+		span.SetTraceAttribute("User", os.Getenv("USER"))
+		span.LogEventWithPayload("ctx", ctx)
+		fmt.Print("\n\nEnter text (empty string to exit): ")
+		text, _ := reader.ReadString('\n')
+		text = strings.TrimSpace(text)
+		if len(text) == 0 {
+			fmt.Println("Exiting.")
+			os.Exit(0)
+		}
+
+		span.LogEvent(text)
+
+		httpClient := &http.Client{}
+		httpReq, _ := http.NewRequest("POST", "http://localhost:8080/", bytes.NewReader([]byte(text)))
+		opentracing.InjectSpanInHeader(span, httpReq.Header)
+		resp, err := httpClient.Do(httpReq)
+		if err != nil {
+			span.LogEventWithPayload("error", err)
+		} else {
+			span.LogEventWithPayload("got response", resp)
+		}
+
+		span.Finish()
+	}
+}
+
+func server() {
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		serverSpan, err := opentracing.JoinTraceFromHeader(
+			"serverSpan", req.Header, opentracing.GlobalTracer())
+		if err != nil {
+			panic(err)
+		}
+		serverSpan.SetTag("component", "server")
+		defer serverSpan.Finish()
+
+		fullBody, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			serverSpan.LogEventWithPayload("body read error", err)
+		}
+		serverSpan.LogEventWithPayload("got request with body", string(fullBody))
+	})
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}
+
+func main() {
+	opentracing.InitGlobalTracer(dapperish.NewTracer("dapperish_tester"))
+
+	go server()
+	go client()
+
+	runtime.Goexit()
+}

--- a/examples/dapperish/dapper.go
+++ b/examples/dapperish/dapper.go
@@ -1,0 +1,11 @@
+package dapperish
+
+import (
+	"github.com/opentracing/basictracer-go"
+	"github.com/opentracing/opentracing-go"
+)
+
+// NewTracer returns a new dapperish Tracer instance.
+func NewTracer(processName string) opentracing.Tracer {
+	return basictracer.New(NewTrivialRecorder(processName))
+}

--- a/examples/dapperish/random.go
+++ b/examples/dapperish/random.go
@@ -1,0 +1,20 @@
+package dapperish
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var (
+	seededIDGen  = rand.New(rand.NewSource(time.Now().UnixNano()))
+	seededIDLock sync.Mutex
+)
+
+// Generate [UnixNano-seeded] pseudorandom numbers.
+func randomID() int64 {
+	// The golang rand generators are *not* intrinsically thread-safe.
+	seededIDLock.Lock()
+	defer seededIDLock.Unlock()
+	return seededIDGen.Int63()
+}

--- a/examples/dapperish/trivialrecorder.go
+++ b/examples/dapperish/trivialrecorder.go
@@ -1,0 +1,43 @@
+package dapperish
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/opentracing/basictracer-go"
+)
+
+// TrivialRecorder implements the basictracer.Recorder interface.
+type TrivialRecorder struct {
+	processName string
+	tags        map[string]string
+}
+
+// NewTrivialRecorder returns a TrivialRecorder for the given `processName`.
+func NewTrivialRecorder(processName string) *TrivialRecorder {
+	return &TrivialRecorder{
+		processName: processName,
+		tags:        make(map[string]string),
+	}
+}
+
+// ProcessName returns the process name.
+func (t *TrivialRecorder) ProcessName() string { return t.processName }
+
+// SetTag sets a tag.
+func (t *TrivialRecorder) SetTag(key string, val interface{}) *TrivialRecorder {
+	t.tags[key] = fmt.Sprint(val)
+	return t
+}
+
+// RecordSpan complies with the basictracer.Recorder interface.
+func (t *TrivialRecorder) RecordSpan(span basictracer.RawSpan) {
+	fmt.Printf(
+		"RecordSpan: %v[%v, %v us] --> %v logs. std context: %v\n",
+		span.Operation, span.Start, span.Duration, len(span.Logs),
+		span.Context)
+	for i, l := range span.Logs {
+		fmt.Printf(
+			"    log %v @ %v: %v --> %v\n", i, l.Timestamp, l.Event, reflect.TypeOf(l.Payload))
+	}
+}


### PR DESCRIPTION
Part of breaking the test dependency loop between `opentracing-go` and `basictracer-go`. Per https://github.com/opentracing/opentracing-go/pull/62.