### PR TITLE
Add AccessorCarrier

### DIFF
--- a/propagation.go
+++ b/propagation.go
@@ -1,113 +1,69 @@
 package basictracer
 
 import (
-	"bytes"
-	"encoding/base64"
-	"encoding/binary"
-	"io"
-	"net/http"
-	"strconv"
-	"strings"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-type splitTextPropagator struct {
+type accessorPropagator struct {
 	tracer *tracerImpl
 }
-type splitBinaryPropagator struct {
-	tracer *tracerImpl
-}
-type goHTTPPropagator struct {
-	*splitBinaryPropagator
+
+// DelegatingCarrier is a flexible carrier interface which can be implemented
+// by types which have a means of storing the trace metadata and already know
+// how to serialize themselves (for example, protocol buffers).
+type DelegatingCarrier interface {
+	SetState(traceID, spanID int64, sampled bool)
+	State() (traceID, spanID int64, sampled bool)
+	SetBaggageItem(key, value string)
+	GetBaggage(func(key, value string))
 }
 
-const (
-	fieldNameTraceID = "traceid"
-	fieldNameSpanID  = "spanid"
-	fieldNameSampled = "sampled"
-)
-
-func (p *splitTextPropagator) InjectSpan(
+func (p *accessorPropagator) InjectSpan(
 	sp opentracing.Span,
 	carrier interface{},
 ) error {
-	sc := sp.(*spanImpl)
-	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
-	if !ok {
+	ac, ok := carrier.(DelegatingCarrier)
+	if !ok || ac == nil {
 		return opentracing.ErrInvalidCarrier
 	}
-	if splitTextCarrier.TracerState == nil {
-		splitTextCarrier.TracerState = make(map[string]string, 3 /* see below */)
+	si, ok := sp.(*spanImpl)
+	if !ok {
+		return opentracing.ErrInvalidSpan
 	}
-	splitTextCarrier.TracerState[fieldNameTraceID] = strconv.FormatInt(sc.raw.TraceID, 10)
-	splitTextCarrier.TracerState[fieldNameSpanID] = strconv.FormatInt(sc.raw.SpanID, 10)
-	splitTextCarrier.TracerState[fieldNameSampled] = strconv.FormatBool(sc.raw.Sampled)
-
-	sc.Lock()
-	if l := len(sc.raw.Baggage); l > 0 && splitTextCarrier.Baggage == nil {
-		splitTextCarrier.Baggage = make(map[string]string, l)
+	meta := si.raw.Context
+	ac.SetState(meta.TraceID, meta.SpanID, meta.Sampled)
+	for k, v := range si.raw.Baggage {
+		ac.SetBaggageItem(k, v)
 	}
-	for k, v := range sc.raw.Baggage {
-		splitTextCarrier.Baggage[k] = v
-	}
-	sc.Unlock()
 	return nil
 }
 
-func (p *splitTextPropagator) JoinTrace(
+func (p *accessorPropagator) JoinTrace(
 	operationName string,
 	carrier interface{},
 ) (opentracing.Span, error) {
-	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
-	if !ok {
+	ac, ok := carrier.(DelegatingCarrier)
+	if !ok || ac == nil {
 		return nil, opentracing.ErrInvalidCarrier
-	}
-	requiredFieldCount := 0
-	var traceID, propagatedSpanID int64
-	var sampled bool
-	var err error
-	for k, v := range splitTextCarrier.TracerState {
-		switch strings.ToLower(k) {
-		case fieldNameTraceID:
-			traceID, err = strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return nil, opentracing.ErrTraceCorrupted
-			}
-		case fieldNameSpanID:
-			propagatedSpanID, err = strconv.ParseInt(v, 10, 64)
-			if err != nil {
-				return nil, opentracing.ErrTraceCorrupted
-			}
-		case fieldNameSampled:
-			sampled, err = strconv.ParseBool(v)
-			if err != nil {
-				return nil, opentracing.ErrTraceCorrupted
-			}
-		default:
-			continue
-		}
-		requiredFieldCount++
-	}
-	const expFieldCount = 3
-	if requiredFieldCount < expFieldCount {
-		if len(splitTextCarrier.TracerState) == 0 {
-			return nil, opentracing.ErrTraceNotFound
-		}
-		return nil, opentracing.ErrTraceCorrupted
 	}
 
 	sp := p.tracer.getSpan()
-	sp.raw = RawSpan{
-		Context: Context{
-			TraceID:      traceID,
-			SpanID:       randomID(),
-			ParentSpanID: propagatedSpanID,
-			Sampled:      sampled,
-		},
+	ac.GetBaggage(func(k, v string) {
+		if sp.raw.Baggage == nil {
+			sp.raw.Baggage = map[string]string{}
+		}
+		sp.raw.Baggage[k] = v
+	})
+
+	traceID, parentSpanID, sampled := ac.State()
+	sp.raw.Context = Context{
+		TraceID:      traceID,
+		SpanID:       randomID(),
+		ParentSpanID: parentSpanID,
+		Sampled:      sampled,
 	}
-	sp.raw.Baggage = splitTextCarrier.Baggage
 
 	return p.tracer.startSpanInternal(
 		sp,
@@ -115,193 +71,4 @@ func (p *splitTextPropagator) JoinTrace(
 		time.Now(),
 		nil,
 	), nil
-}
-
-func (p *splitBinaryPropagator) InjectSpan(
-	sp opentracing.Span,
-	carrier interface{},
-) error {
-	sc := sp.(*spanImpl)
-	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
-	if !ok {
-		return opentracing.ErrInvalidCarrier
-	}
-	var err error
-	var sampledByte byte
-	if sc.raw.Sampled {
-		sampledByte = 1
-	}
-
-	// Handle the trace and span ids, and sampled status.
-	contextBuf := bytes.NewBuffer(splitBinaryCarrier.TracerState[:0])
-	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.TraceID)
-	if err != nil {
-		return err
-	}
-
-	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.SpanID)
-	if err != nil {
-		return err
-	}
-
-	err = binary.Write(contextBuf, binary.BigEndian, sampledByte)
-	if err != nil {
-		return err
-	}
-
-	// Handle the baggageibutes.
-	baggageBuf := bytes.NewBuffer(splitBinaryCarrier.Baggage[:0])
-	err = binary.Write(baggageBuf, binary.BigEndian, int32(len(sc.raw.Baggage)))
-	if err != nil {
-		return err
-	}
-	for k, v := range sc.raw.Baggage {
-		if err = binary.Write(baggageBuf, binary.BigEndian, int32(len(k))); err != nil {
-			return err
-		}
-		baggageBuf.WriteString(k)
-		if err = binary.Write(baggageBuf, binary.BigEndian, int32(len(v))); err != nil {
-			return err
-		}
-		baggageBuf.WriteString(v)
-	}
-
-	splitBinaryCarrier.TracerState = contextBuf.Bytes()
-	splitBinaryCarrier.Baggage = baggageBuf.Bytes()
-	return nil
-}
-
-func (p *splitBinaryPropagator) JoinTrace(
-	operationName string,
-	carrier interface{},
-) (opentracing.Span, error) {
-	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
-	if !ok {
-		return nil, opentracing.ErrInvalidCarrier
-	}
-	if len(splitBinaryCarrier.TracerState) == 0 {
-		return nil, opentracing.ErrTraceNotFound
-	}
-	// Handle the trace, span ids, and sampled status.
-	contextReader := bytes.NewReader(splitBinaryCarrier.TracerState)
-	var traceID, propagatedSpanID int64
-	var sampledByte byte
-
-	if err := binary.Read(contextReader, binary.BigEndian, &traceID); err != nil {
-		return nil, opentracing.ErrTraceCorrupted
-	}
-	if err := binary.Read(contextReader, binary.BigEndian, &propagatedSpanID); err != nil {
-		return nil, opentracing.ErrTraceCorrupted
-	}
-	if err := binary.Read(contextReader, binary.BigEndian, &sampledByte); err != nil {
-		return nil, opentracing.ErrTraceCorrupted
-	}
-
-	// Handle the baggageibutes.
-	baggageReader := bytes.NewReader(splitBinaryCarrier.Baggage)
-	var numBaggage int32
-	if err := binary.Read(baggageReader, binary.BigEndian, &numBaggage); err != nil {
-		return nil, opentracing.ErrTraceCorrupted
-	}
-	iNumBaggage := int(numBaggage)
-	var baggageMap map[string]string
-	if iNumBaggage > 0 {
-		var buf bytes.Buffer // TODO(tschottdorf): candidate for sync.Pool
-		baggageMap = make(map[string]string, iNumBaggage)
-		var keyLen, valLen int32
-		for i := 0; i < iNumBaggage; i++ {
-			if err := binary.Read(baggageReader, binary.BigEndian, &keyLen); err != nil {
-				return nil, opentracing.ErrTraceCorrupted
-			}
-			buf.Grow(int(keyLen))
-			if n, err := io.CopyN(&buf, baggageReader, int64(keyLen)); err != nil || int32(n) != keyLen {
-				return nil, opentracing.ErrTraceCorrupted
-			}
-			key := buf.String()
-			buf.Reset()
-
-			if err := binary.Read(baggageReader, binary.BigEndian, &valLen); err != nil {
-				return nil, opentracing.ErrTraceCorrupted
-			}
-			if n, err := io.CopyN(&buf, baggageReader, int64(valLen)); err != nil || int32(n) != valLen {
-				return nil, opentracing.ErrTraceCorrupted
-			}
-			baggageMap[key] = buf.String()
-			buf.Reset()
-		}
-	}
-
-	sp := p.tracer.getSpan()
-	sp.raw = RawSpan{
-		Context: Context{
-			TraceID:      traceID,
-			SpanID:       randomID(),
-			ParentSpanID: propagatedSpanID,
-			Sampled:      sampledByte != 0,
-		},
-	}
-	sp.raw.Baggage = baggageMap
-
-	return p.tracer.startSpanInternal(
-		sp,
-		operationName,
-		time.Now(),
-		nil,
-	), nil
-}
-
-const (
-	tracerStateHeaderName  = "Tracer-State"
-	traceBaggageHeaderName = "Trace-Baggage"
-)
-
-func (p *goHTTPPropagator) InjectSpan(
-	sp opentracing.Span,
-	carrier interface{},
-) error {
-	// Defer to SplitBinary for the real work.
-	splitBinaryCarrier := opentracing.NewSplitBinaryCarrier()
-	if err := p.splitBinaryPropagator.InjectSpan(sp, splitBinaryCarrier); err != nil {
-		return err
-	}
-
-	// Encode into the HTTP header as two base64 strings.
-	header := carrier.(http.Header)
-	header.Add(tracerStateHeaderName, base64.StdEncoding.EncodeToString(
-		splitBinaryCarrier.TracerState))
-	header.Add(traceBaggageHeaderName, base64.StdEncoding.EncodeToString(
-		splitBinaryCarrier.Baggage))
-
-	return nil
-}
-
-func (p *goHTTPPropagator) JoinTrace(
-	operationName string,
-	carrier interface{},
-) (opentracing.Span, error) {
-	// Decode the two base64-encoded data blobs from the HTTP header.
-	header := carrier.(http.Header)
-	tracerStateBase64, found := header[http.CanonicalHeaderKey(tracerStateHeaderName)]
-	if !found || len(tracerStateBase64) == 0 {
-		return nil, opentracing.ErrTraceNotFound
-	}
-	traceBaggageBase64, found := header[http.CanonicalHeaderKey(traceBaggageHeaderName)]
-	if !found || len(traceBaggageBase64) == 0 {
-		return nil, opentracing.ErrTraceNotFound
-	}
-	tracerStateBinary, err := base64.StdEncoding.DecodeString(tracerStateBase64[0])
-	if err != nil {
-		return nil, opentracing.ErrTraceCorrupted
-	}
-	traceBaggageBinary, err := base64.StdEncoding.DecodeString(traceBaggageBase64[0])
-	if err != nil {
-		return nil, opentracing.ErrTraceCorrupted
-	}
-
-	// Defer to SplitBinary for the real work.
-	splitBinaryCarrier := &opentracing.SplitBinaryCarrier{
-		TracerState: tracerStateBinary,
-		Baggage:     traceBaggageBinary,
-	}
-	return p.splitBinaryPropagator.JoinTrace(operationName, splitBinaryCarrier)
 }

--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -1,0 +1,313 @@
+package basictracer
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	opentracing "github.com/opentracing/opentracing-go"
+)
+
+type splitTextPropagator struct {
+	tracer *tracerImpl
+}
+type splitBinaryPropagator struct {
+	tracer *tracerImpl
+}
+type goHTTPPropagator struct {
+	*splitBinaryPropagator
+}
+
+const (
+	fieldNameTraceID = "traceid"
+	fieldNameSpanID  = "spanid"
+	fieldNameSampled = "sampled"
+)
+
+func (p *splitTextPropagator) InjectSpan(
+	sp opentracing.Span,
+	carrier interface{},
+) error {
+	sc, ok := sp.(*spanImpl)
+	if !ok {
+		return opentracing.ErrInvalidSpan
+	}
+	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
+	if !ok {
+		return opentracing.ErrInvalidCarrier
+	}
+	if splitTextCarrier.TracerState == nil {
+		splitTextCarrier.TracerState = make(map[string]string, 3 /* see below */)
+	}
+	splitTextCarrier.TracerState[fieldNameTraceID] = strconv.FormatInt(sc.raw.TraceID, 10)
+	splitTextCarrier.TracerState[fieldNameSpanID] = strconv.FormatInt(sc.raw.SpanID, 10)
+	splitTextCarrier.TracerState[fieldNameSampled] = strconv.FormatBool(sc.raw.Sampled)
+
+	sc.Lock()
+	if l := len(sc.raw.Baggage); l > 0 && splitTextCarrier.Baggage == nil {
+		splitTextCarrier.Baggage = make(map[string]string, l)
+	}
+	for k, v := range sc.raw.Baggage {
+		splitTextCarrier.Baggage[k] = v
+	}
+	sc.Unlock()
+	return nil
+}
+
+func (p *splitTextPropagator) JoinTrace(
+	operationName string,
+	carrier interface{},
+) (opentracing.Span, error) {
+	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
+	if !ok {
+		return nil, opentracing.ErrInvalidCarrier
+	}
+	requiredFieldCount := 0
+	var traceID, propagatedSpanID int64
+	var sampled bool
+	var err error
+	for k, v := range splitTextCarrier.TracerState {
+		switch strings.ToLower(k) {
+		case fieldNameTraceID:
+			traceID, err = strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return nil, opentracing.ErrTraceCorrupted
+			}
+		case fieldNameSpanID:
+			propagatedSpanID, err = strconv.ParseInt(v, 10, 64)
+			if err != nil {
+				return nil, opentracing.ErrTraceCorrupted
+			}
+		case fieldNameSampled:
+			sampled, err = strconv.ParseBool(v)
+			if err != nil {
+				return nil, opentracing.ErrTraceCorrupted
+			}
+		default:
+			continue
+		}
+		requiredFieldCount++
+	}
+	const expFieldCount = 3
+	if requiredFieldCount < expFieldCount {
+		if len(splitTextCarrier.TracerState) == 0 {
+			return nil, opentracing.ErrTraceNotFound
+		}
+		return nil, opentracing.ErrTraceCorrupted
+	}
+
+	sp := p.tracer.getSpan()
+	sp.raw = RawSpan{
+		Context: Context{
+			TraceID:      traceID,
+			SpanID:       randomID(),
+			ParentSpanID: propagatedSpanID,
+			Sampled:      sampled,
+		},
+	}
+	sp.raw.Baggage = splitTextCarrier.Baggage
+
+	return p.tracer.startSpanInternal(
+		sp,
+		operationName,
+		time.Now(),
+		nil,
+	), nil
+}
+
+func (p *splitBinaryPropagator) InjectSpan(
+	sp opentracing.Span,
+	carrier interface{},
+) error {
+	sc, ok := sp.(*spanImpl)
+	if !ok {
+		return opentracing.ErrInvalidSpan
+	}
+	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
+	if !ok {
+		return opentracing.ErrInvalidCarrier
+	}
+	var err error
+	var sampledByte byte
+	if sc.raw.Sampled {
+		sampledByte = 1
+	}
+
+	// Handle the trace and span ids, and sampled status.
+	contextBuf := bytes.NewBuffer(splitBinaryCarrier.TracerState[:0])
+	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.TraceID)
+	if err != nil {
+		return err
+	}
+
+	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.SpanID)
+	if err != nil {
+		return err
+	}
+
+	err = binary.Write(contextBuf, binary.BigEndian, sampledByte)
+	if err != nil {
+		return err
+	}
+
+	// Handle the baggage.
+	baggageBuf := bytes.NewBuffer(splitBinaryCarrier.Baggage[:0])
+	err = binary.Write(baggageBuf, binary.BigEndian, int32(len(sc.raw.Baggage)))
+	if err != nil {
+		return err
+	}
+	for k, v := range sc.raw.Baggage {
+		if err = binary.Write(baggageBuf, binary.BigEndian, int32(len(k))); err != nil {
+			return err
+		}
+		baggageBuf.WriteString(k)
+		if err = binary.Write(baggageBuf, binary.BigEndian, int32(len(v))); err != nil {
+			return err
+		}
+		baggageBuf.WriteString(v)
+	}
+
+	splitBinaryCarrier.TracerState = contextBuf.Bytes()
+	splitBinaryCarrier.Baggage = baggageBuf.Bytes()
+	return nil
+}
+
+func (p *splitBinaryPropagator) JoinTrace(
+	operationName string,
+	carrier interface{},
+) (opentracing.Span, error) {
+	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
+	if !ok {
+		return nil, opentracing.ErrInvalidCarrier
+	}
+	if len(splitBinaryCarrier.TracerState) == 0 {
+		return nil, opentracing.ErrTraceNotFound
+	}
+	// Handle the trace, span ids, and sampled status.
+	contextReader := bytes.NewReader(splitBinaryCarrier.TracerState)
+	var traceID, propagatedSpanID int64
+	var sampledByte byte
+
+	if err := binary.Read(contextReader, binary.BigEndian, &traceID); err != nil {
+		return nil, opentracing.ErrTraceCorrupted
+	}
+	if err := binary.Read(contextReader, binary.BigEndian, &propagatedSpanID); err != nil {
+		return nil, opentracing.ErrTraceCorrupted
+	}
+	if err := binary.Read(contextReader, binary.BigEndian, &sampledByte); err != nil {
+		return nil, opentracing.ErrTraceCorrupted
+	}
+
+	// Handle the baggage.
+	baggageReader := bytes.NewReader(splitBinaryCarrier.Baggage)
+	var numBaggage int32
+	if err := binary.Read(baggageReader, binary.BigEndian, &numBaggage); err != nil {
+		return nil, opentracing.ErrTraceCorrupted
+	}
+	iNumBaggage := int(numBaggage)
+	var baggageMap map[string]string
+	if iNumBaggage > 0 {
+		var buf bytes.Buffer // TODO(tschottdorf): candidate for sync.Pool
+		baggageMap = make(map[string]string, iNumBaggage)
+		var keyLen, valLen int32
+		for i := 0; i < iNumBaggage; i++ {
+			if err := binary.Read(baggageReader, binary.BigEndian, &keyLen); err != nil {
+				return nil, opentracing.ErrTraceCorrupted
+			}
+			buf.Grow(int(keyLen))
+			if n, err := io.CopyN(&buf, baggageReader, int64(keyLen)); err != nil || int32(n) != keyLen {
+				return nil, opentracing.ErrTraceCorrupted
+			}
+			key := buf.String()
+			buf.Reset()
+
+			if err := binary.Read(baggageReader, binary.BigEndian, &valLen); err != nil {
+				return nil, opentracing.ErrTraceCorrupted
+			}
+			if n, err := io.CopyN(&buf, baggageReader, int64(valLen)); err != nil || int32(n) != valLen {
+				return nil, opentracing.ErrTraceCorrupted
+			}
+			baggageMap[key] = buf.String()
+			buf.Reset()
+		}
+	}
+
+	sp := p.tracer.getSpan()
+	sp.raw = RawSpan{
+		Context: Context{
+			TraceID:      traceID,
+			SpanID:       randomID(),
+			ParentSpanID: propagatedSpanID,
+			Sampled:      sampledByte != 0,
+		},
+	}
+	sp.raw.Baggage = baggageMap
+
+	return p.tracer.startSpanInternal(
+		sp,
+		operationName,
+		time.Now(),
+		nil,
+	), nil
+}
+
+const (
+	tracerStateHeaderName  = "Tracer-State"
+	traceBaggageHeaderName = "Trace-Baggage"
+)
+
+func (p *goHTTPPropagator) InjectSpan(
+	sp opentracing.Span,
+	carrier interface{},
+) error {
+	// Defer to SplitBinary for the real work.
+	splitBinaryCarrier := opentracing.NewSplitBinaryCarrier()
+	if err := p.splitBinaryPropagator.InjectSpan(sp, splitBinaryCarrier); err != nil {
+		return err
+	}
+
+	// Encode into the HTTP header as two base64 strings.
+	header := carrier.(http.Header)
+	header.Add(tracerStateHeaderName, base64.StdEncoding.EncodeToString(
+		splitBinaryCarrier.TracerState))
+	header.Add(traceBaggageHeaderName, base64.StdEncoding.EncodeToString(
+		splitBinaryCarrier.Baggage))
+
+	return nil
+}
+
+func (p *goHTTPPropagator) JoinTrace(
+	operationName string,
+	carrier interface{},
+) (opentracing.Span, error) {
+	// Decode the two base64-encoded data blobs from the HTTP header.
+	header := carrier.(http.Header)
+	tracerStateBase64, found := header[http.CanonicalHeaderKey(tracerStateHeaderName)]
+	if !found || len(tracerStateBase64) == 0 {
+		return nil, opentracing.ErrTraceNotFound
+	}
+	traceBaggageBase64, found := header[http.CanonicalHeaderKey(traceBaggageHeaderName)]
+	if !found || len(traceBaggageBase64) == 0 {
+		return nil, opentracing.ErrTraceNotFound
+	}
+	tracerStateBinary, err := base64.StdEncoding.DecodeString(tracerStateBase64[0])
+	if err != nil {
+		return nil, opentracing.ErrTraceCorrupted
+	}
+	traceBaggageBinary, err := base64.StdEncoding.DecodeString(traceBaggageBase64[0])
+	if err != nil {
+		return nil, opentracing.ErrTraceCorrupted
+	}
+
+	// Defer to SplitBinary for the real work.
+	splitBinaryCarrier := &opentracing.SplitBinaryCarrier{
+		TracerState: tracerStateBinary,
+		Baggage:     traceBaggageBinary,
+	}
+	return p.splitBinaryPropagator.JoinTrace(operationName, splitBinaryCarrier)
+}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -1,18 +1,43 @@
 package basictracer_test
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"github.com/opentracing/basictracer-go"
+	basictracer "github.com/opentracing/basictracer-go"
 	"github.com/opentracing/basictracer-go/testutils"
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
+type verbatimCarrier struct {
+	basictracer.Context
+	b map[string]string
+}
+
+var _ basictracer.DelegatingCarrier = &verbatimCarrier{}
+
+func (vc *verbatimCarrier) SetBaggageItem(k, v string) {
+	vc.b[k] = v
+}
+
+func (vc *verbatimCarrier) GetBaggage(f func(string, string)) {
+	for k, v := range vc.b {
+		f(k, v)
+	}
+}
+
+func (vc *verbatimCarrier) SetState(tID, sID int64, sampled bool) {
+	vc.Context = basictracer.Context{TraceID: tID, SpanID: sID, Sampled: sampled}
+}
+
+func (vc *verbatimCarrier) State() (traceID, spanID int64, sampled bool) {
+	return vc.Context.TraceID, vc.Context.SpanID, vc.Context.Sampled
+}
+
 func TestSpanPropagator(t *testing.T) {
-	var err error
 	const op = "test"
 	recorder := testutils.NewInMemoryRecorder()
 	tracer := basictracer.New(recorder)
@@ -20,52 +45,54 @@ func TestSpanPropagator(t *testing.T) {
 	sp := tracer.StartSpan(op)
 	sp.SetBaggageItem("foo", "bar")
 
-	textCarrier := opentracing.NewSplitTextCarrier()
-	err = tracer.Injector(opentracing.SplitText).InjectSpan(sp, textCarrier)
-	if err != nil {
-		t.Fatal(err)
-	}
-	binaryCarrier := opentracing.NewSplitBinaryCarrier()
-	err = tracer.Injector(opentracing.SplitBinary).InjectSpan(sp, binaryCarrier)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		typ, carrier interface{}
+	}{
+		{basictracer.Accessor, basictracer.DelegatingCarrier(&verbatimCarrier{b: map[string]string{}})},
+		{opentracing.SplitBinary, opentracing.NewSplitBinaryCarrier()},
+		{opentracing.SplitText, opentracing.NewSplitTextCarrier()},
+		{opentracing.GoHTTPHeader, http.Header{}},
 	}
 
-	sp1, err := tracer.Extractor(opentracing.SplitText).JoinTrace(op, textCarrier)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sp2, err := tracer.Extractor(opentracing.SplitBinary).JoinTrace(op, binaryCarrier)
-	if err != nil {
-		t.Fatal(err)
+	for i, test := range tests {
+		inj := tracer.Injector(test.typ)
+		if inj == nil {
+			t.Fatalf("%d: no injector found for %T", i, test.carrier)
+		}
+		if err := inj.InjectSpan(sp, test.carrier); err != nil {
+			t.Fatalf("%d: %v", i, err)
+		}
+		child, err := tracer.Extractor(test.typ).JoinTrace(op, test.carrier)
+		if err != nil {
+			t.Fatalf("%d: %v", i, err)
+		}
+		child.Finish()
 	}
 	sp.Finish()
-	for _, sp := range []opentracing.Span{sp1, sp2} {
-		sp.Finish()
-	}
 
 	spans := recorder.GetSpans()
-	if a, e := len(spans), 3; a != e {
+	if a, e := len(spans), len(tests)+1; a != e {
 		t.Fatalf("expected %d spans, got %d", e, a)
 	}
 
-	exp := spans[0]
+	// The last span is the original one.
+	exp, spans := spans[len(spans)-1], spans[:len(spans)-1]
 	exp.Duration = time.Duration(123)
 	exp.Start = time.Time{}.Add(1)
 
-	for i, sp := range spans[1:] {
+	for i, sp := range spans {
 		if a, e := sp.ParentSpanID, exp.SpanID; a != e {
-			t.Errorf("%d: ParentSpanID %d does not match expectation %d", i, a, e)
+			t.Fatalf("%d: ParentSpanID %d does not match expectation %d", i, a, e)
 		} else {
 			// Prepare for comparison.
 			sp.SpanID, sp.ParentSpanID = exp.SpanID, 0
 			sp.Duration, sp.Start = exp.Duration, exp.Start
 		}
 		if a, e := sp.TraceID, exp.TraceID; a != e {
-			t.Errorf("%d: TraceID changed from %d to %d", i, e, a)
+			t.Fatalf("%d: TraceID changed from %d to %d", i, e, a)
 		}
 		if !reflect.DeepEqual(exp, sp) {
-			t.Errorf("%d: wanted %+v, got %+v", i, spew.Sdump(exp), spew.Sdump(sp))
+			t.Fatalf("%d: wanted %+v, got %+v", i, spew.Sdump(exp), spew.Sdump(sp))
 		}
 	}
 }

--- a/span.go
+++ b/span.go
@@ -19,8 +19,22 @@ type spanImpl struct {
 
 func (s *spanImpl) reset() {
 	s.tracer = nil
+	// Note: Would like to do the following, but then the consumer of RawSpan
+	// (the recorder) needs to make sure that they're not holding on to the
+	// baggage or logs when they return (i.e. they need to copy if they care):
+	//
+	// logs, baggage := s.raw.Logs[:0], s.raw.Baggage
+	// for k := range baggage {
+	// 	delete(baggage, k)
+	// }
+	// s.raw.Logs, s.raw.Baggage = logs, baggage
+	//
+	// That's likely too much to ask for. But there is some magic we should
+	// be able to do with `runtime.SetFinalizer` to reclaim that memory into
+	// a buffer pool when GC considers them unreachable, which should ease
+	// some of the load. Hard to say how quickly that would be in practice
+	// though.
 	s.raw = RawSpan{}
-	s.raw.Baggage = nil // TODO(tschottdorf): is clearing out the map better?
 }
 
 func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {


### PR DESCRIPTION
AccessorCarrier is a carrier type which, for example, can be used
by protobufs (or any general struct that is part of an RPC payload
which already knows how to serialize itself) to copy the relevant
data inbetween itself and the Span.

Apologies for the big diff. I moved the carrier stuff which corresponds
to OT standards into `propagation_ot.go` (with only trivial adjustments).
Should've factored that out into an extra commit.