### PR TITLE
Add Events API to allow flexible extension

### DIFF
--- a/event.go
+++ b/event.go
@@ -1,0 +1,52 @@
+package basictracer
+
+import "github.com/opentracing/opentracing-go"
+
+// A SpanEvent is emitted when a mutating command is called on a Span.
+type SpanEvent interface{}
+
+// EventCreate is emitted when a Span is created.
+type EventCreate struct{ OperationName string }
+
+// EventTag is received when SetTag is called.
+type EventTag struct {
+	Key   string
+	Value interface{}
+}
+
+// EventBaggage is received when SetBaggageItem is called.
+type EventBaggage struct {
+	Key, Value string
+}
+
+// EventLog is received when Log (or one of its derivatives) is called.
+type EventLog opentracing.LogData
+
+// EventFinish is received when Finish is called.
+type EventFinish RawSpan
+
+func (s *spanImpl) onCreate(opName string) {
+	if s.event != nil {
+		s.event(EventCreate{OperationName: opName})
+	}
+}
+func (s *spanImpl) onTag(key string, value interface{}) {
+	if s.event != nil {
+		s.event(EventTag{Key: key, Value: value})
+	}
+}
+func (s *spanImpl) onLog(ld opentracing.LogData) {
+	if s.event != nil {
+		s.event(EventLog(ld))
+	}
+}
+func (s *spanImpl) onBaggage(key, value string) {
+	if s.event != nil {
+		s.event(EventBaggage{Key: key, Value: value})
+	}
+}
+func (s *spanImpl) onFinish(sp RawSpan) {
+	if s.event != nil {
+		s.event(EventFinish(sp))
+	}
+}

--- a/event_nettrace.go
+++ b/event_nettrace.go
@@ -1,0 +1,23 @@
+package basictracer
+
+import "golang.org/x/net/trace"
+
+// NetTraceIntegrator can be passed into a basictracer as NewSpanEventListener
+// and causes all traces to be registered with the net/trace endpoint.
+var NetTraceIntegrator = func() func(SpanEvent) {
+	var tr trace.Trace
+	return func(e SpanEvent) {
+		switch t := e.(type) {
+		case EventCreate:
+			tr = trace.New("tracing", t.OperationName)
+		case EventFinish:
+			tr.Finish()
+		case EventLog:
+			if t.Payload != nil {
+				tr.LazyPrintf("%s (payload %v)", t.Event, t.Payload)
+			} else {
+				tr.LazyPrintf("%s", t.Event)
+			}
+		}
+	}
+}


### PR DESCRIPTION
The goal of this API is to allow many more integrations of
basictracer without having to fork it.

As a practical example, implemented NetTraceIntegrator, which automatically
registers and tracks all Spans with the net/trace endpoint.

This was further motivated by the open PR

  https://github.com/sourcegraph/appdash/pull/110

which should, at least after some more iteration on the API presented here,
be able to work with a vanilla basictracer, thus avoiding maintaining an ever
so slightly different copy of basictracer in the `appdash` repo.

Needs some tests, but I'll get to that tomorrow.