### PR TITLE
Make SplitTextCarrier work with superset maps

### DIFF
--- a/examples/dapperish.go
+++ b/examples/dapperish.go
@@ -18,8 +18,8 @@ import (
 func client() {
 	reader := bufio.NewReader(os.Stdin)
 	for {
-		ctx, span := opentracing.BackgroundContextWithSpan(
-			opentracing.StartSpan("getInput"))
+		span := opentracing.StartSpan("getInput")
+		ctx := opentracing.BackgroundContextWithSpan(span)
 		// Make sure that global baggage propagation works.
 		span.SetBaggageItem("User", os.Getenv("USER"))
 		span.LogEventWithPayload("ctx", ctx)


### PR DESCRIPTION
For example, passing Go's http.Header map into both TracerState and Baggage should work. Related to https://github.com/opentracing/opentracing.github.io/issues/73.