### PR TITLE
Move to interface-based carriers

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
 package basictracer
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
 	"testing"
@@ -99,9 +100,9 @@ func benchmarkInject(b *testing.B, format opentracing.BuiltinFormat, numItems in
 	var carrier interface{}
 	switch format {
 	case opentracing.TextMap:
-		carrier = opentracing.TextMapCarrier{}
+		carrier = opentracing.HTTPHeaderTextMapCarrier{}
 	case opentracing.Binary:
-		carrier = opentracing.BinaryCarrier(&[]byte{})
+		carrier = opentracing.BinaryCarrier(&bytes.Buffer{})
 	case opentracing.GoHTTPHeader:
 		carrier = http.Header{}
 	default:
@@ -124,9 +125,9 @@ func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int)
 	var carrier interface{}
 	switch format {
 	case opentracing.TextMap:
-		carrier = opentracing.TextMapCarrier{}
+		carrier = opentracing.HTTPHeaderTextMapCarrier{}
 	case opentracing.Binary:
-		carrier = opentracing.BinaryCarrier(&[]byte{})
+		carrier = opentracing.BinaryCarrier(&bytes.Buffer{})
 	case opentracing.GoHTTPHeader:
 		carrier = http.Header{}
 	default:

--- a/bench_test.go
+++ b/bench_test.go
@@ -98,10 +98,10 @@ func benchmarkInject(b *testing.B, format opentracing.BuiltinFormat, numItems in
 	executeOps(sp, 0, 0, numItems)
 	var carrier interface{}
 	switch format {
-	case opentracing.SplitText:
-		carrier = opentracing.NewSplitTextCarrier()
-	case opentracing.SplitBinary:
-		carrier = opentracing.NewSplitBinaryCarrier()
+	case opentracing.TextMap:
+		carrier = opentracing.TextMapCarrier{}
+	case opentracing.Binary:
+		carrier = opentracing.BinaryCarrier(&[]byte{})
 	case opentracing.GoHTTPHeader:
 		carrier = http.Header{}
 	default:
@@ -123,10 +123,10 @@ func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int)
 	executeOps(sp, 0, 0, numItems)
 	var carrier interface{}
 	switch format {
-	case opentracing.SplitText:
-		carrier = opentracing.NewSplitTextCarrier()
-	case opentracing.SplitBinary:
-		carrier = opentracing.NewSplitBinaryCarrier()
+	case opentracing.TextMap:
+		carrier = opentracing.TextMapCarrier{}
+	case opentracing.Binary:
+		carrier = opentracing.BinaryCarrier(&[]byte{})
 	case opentracing.GoHTTPHeader:
 		carrier = http.Header{}
 	default:
@@ -145,12 +145,12 @@ func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int)
 	}
 }
 
-func BenchmarkInject_SplitText_Empty(b *testing.B) {
-	benchmarkInject(b, opentracing.SplitText, 0)
+func BenchmarkInject_TextMap_Empty(b *testing.B) {
+	benchmarkInject(b, opentracing.TextMap, 0)
 }
 
-func BenchmarkInject_SplitText_100BaggageItems(b *testing.B) {
-	benchmarkInject(b, opentracing.SplitText, 100)
+func BenchmarkInject_TextMap_100BaggageItems(b *testing.B) {
+	benchmarkInject(b, opentracing.TextMap, 100)
 }
 
 func BenchmarkInject_GoHTTPHeader_Empty(b *testing.B) {
@@ -161,20 +161,20 @@ func BenchmarkInject_GoHTTPHeader_100BaggageItems(b *testing.B) {
 	benchmarkInject(b, opentracing.GoHTTPHeader, 100)
 }
 
-func BenchmarkInject_SplitBinary_Empty(b *testing.B) {
-	benchmarkInject(b, opentracing.SplitBinary, 0)
+func BenchmarkInject_Binary_Empty(b *testing.B) {
+	benchmarkInject(b, opentracing.Binary, 0)
 }
 
-func BenchmarkInject_SplitBinary_100BaggageItems(b *testing.B) {
-	benchmarkInject(b, opentracing.SplitBinary, 100)
+func BenchmarkInject_Binary_100BaggageItems(b *testing.B) {
+	benchmarkInject(b, opentracing.Binary, 100)
 }
 
-func BenchmarkJoin_SplitText_Empty(b *testing.B) {
-	benchmarkJoin(b, opentracing.SplitText, 0)
+func BenchmarkJoin_TextMap_Empty(b *testing.B) {
+	benchmarkJoin(b, opentracing.TextMap, 0)
 }
 
-func BenchmarkJoin_SplitText_100BaggageItems(b *testing.B) {
-	benchmarkJoin(b, opentracing.SplitText, 100)
+func BenchmarkJoin_TextMap_100BaggageItems(b *testing.B) {
+	benchmarkJoin(b, opentracing.TextMap, 100)
 }
 
 func BenchmarkJoin_GoHTTPHeader_Empty(b *testing.B) {
@@ -185,10 +185,10 @@ func BenchmarkJoin_GoHTTPHeader_100BaggageItems(b *testing.B) {
 	benchmarkJoin(b, opentracing.GoHTTPHeader, 100)
 }
 
-func BenchmarkJoin_SplitBinary_Empty(b *testing.B) {
-	benchmarkJoin(b, opentracing.SplitBinary, 0)
+func BenchmarkJoin_Binary_Empty(b *testing.B) {
+	benchmarkJoin(b, opentracing.Binary, 0)
 }
 
-func BenchmarkJoin_SplitBinary_100BaggageItems(b *testing.B) {
-	benchmarkJoin(b, opentracing.SplitBinary, 100)
+func BenchmarkJoin_Binary_100BaggageItems(b *testing.B) {
+	benchmarkJoin(b, opentracing.Binary, 100)
 }

--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -2,10 +2,10 @@ package basictracer
 
 import (
 	"bytes"
-	"encoding/base64"
 	"encoding/binary"
 	"io"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -13,14 +13,14 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
-type splitTextPropagator struct {
+type textMapPropagator struct {
 	tracer *tracerImpl
 }
-type splitBinaryPropagator struct {
+type binaryPropagator struct {
 	tracer *tracerImpl
 }
 type goHTTPPropagator struct {
-	*splitBinaryPropagator
+	*textMapPropagator
 }
 
 const (
@@ -33,41 +33,35 @@ const (
 	fieldNameSampled      = prefixTracerState + "sampled"
 )
 
-func (p *splitTextPropagator) Inject(
+func (p *textMapPropagator) Inject(
 	sp opentracing.Span,
-	carrier interface{},
+	opaqueCarrier interface{},
 ) error {
 	sc, ok := sp.(*spanImpl)
 	if !ok {
 		return opentracing.ErrInvalidSpan
 	}
-	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
+	carrier, ok := opaqueCarrier.(opentracing.TextMapCarrier)
 	if !ok {
 		return opentracing.ErrInvalidCarrier
 	}
-	if splitTextCarrier.TracerState == nil {
-		splitTextCarrier.TracerState = make(map[string]string, tracerStateFieldCount)
-	}
-	splitTextCarrier.TracerState[fieldNameTraceID] = strconv.FormatInt(sc.raw.TraceID, 16)
-	splitTextCarrier.TracerState[fieldNameSpanID] = strconv.FormatInt(sc.raw.SpanID, 16)
-	splitTextCarrier.TracerState[fieldNameSampled] = strconv.FormatBool(sc.raw.Sampled)
+	carrier[fieldNameTraceID] = strconv.FormatInt(sc.raw.TraceID, 16)
+	carrier[fieldNameSpanID] = strconv.FormatInt(sc.raw.SpanID, 16)
+	carrier[fieldNameSampled] = strconv.FormatBool(sc.raw.Sampled)
 
 	sc.Lock()
-	if l := len(sc.raw.Baggage); l > 0 && splitTextCarrier.Baggage == nil {
-		splitTextCarrier.Baggage = make(map[string]string, l)
-	}
 	for k, v := range sc.raw.Baggage {
-		splitTextCarrier.Baggage[prefixBaggage+k] = v
+		carrier[prefixBaggage+k] = v
 	}
 	sc.Unlock()
 	return nil
 }
 
-func (p *splitTextPropagator) Join(
+func (p *textMapPropagator) Join(
 	operationName string,
-	carrier interface{},
+	opaqueCarrier interface{},
 ) (opentracing.Span, error) {
-	splitTextCarrier, ok := carrier.(*opentracing.SplitTextCarrier)
+	carrier, ok := opaqueCarrier.(opentracing.TextMapCarrier)
 	if !ok {
 		return nil, opentracing.ErrInvalidCarrier
 	}
@@ -75,7 +69,8 @@ func (p *splitTextPropagator) Join(
 	var traceID, propagatedSpanID int64
 	var sampled bool
 	var err error
-	for k, v := range splitTextCarrier.TracerState {
+	decodedBaggage := make(map[string]string)
+	for k, v := range carrier {
 		switch strings.ToLower(k) {
 		case fieldNameTraceID:
 			traceID, err = strconv.ParseInt(v, 16, 64)
@@ -93,22 +88,17 @@ func (p *splitTextPropagator) Join(
 				return nil, opentracing.ErrTraceCorrupted
 			}
 		default:
-			continue
-		}
-		requiredFieldCount++
-	}
-	var decodedBaggage map[string]string
-	if splitTextCarrier.Baggage != nil {
-		decodedBaggage = make(map[string]string)
-		for k, v := range splitTextCarrier.Baggage {
 			lowercaseK := strings.ToLower(k)
 			if strings.HasPrefix(lowercaseK, prefixBaggage) {
 				decodedBaggage[strings.TrimPrefix(lowercaseK, prefixBaggage)] = v
 			}
+			// Balance off the requiredFieldCount++ just below...
+			requiredFieldCount--
 		}
+		requiredFieldCount++
 	}
 	if requiredFieldCount < tracerStateFieldCount {
-		if len(splitTextCarrier.TracerState) == 0 {
+		if requiredFieldCount == 0 {
 			return nil, opentracing.ErrTraceNotFound
 		}
 		return nil, opentracing.ErrTraceCorrupted
@@ -133,18 +123,19 @@ func (p *splitTextPropagator) Join(
 	), nil
 }
 
-func (p *splitBinaryPropagator) Inject(
+func (p *binaryPropagator) Inject(
 	sp opentracing.Span,
-	carrier interface{},
+	opaqueCarrier interface{},
 ) error {
 	sc, ok := sp.(*spanImpl)
 	if !ok {
 		return opentracing.ErrInvalidSpan
 	}
-	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
+	carrier, ok := opaqueCarrier.(opentracing.BinaryCarrier)
 	if !ok {
 		return opentracing.ErrInvalidCarrier
 	}
+	buffer := &bytes.Buffer{}
 	var err error
 	var sampledByte byte
 	if sc.raw.Sampled {
@@ -152,74 +143,75 @@ func (p *splitBinaryPropagator) Inject(
 	}
 
 	// Handle the trace and span ids, and sampled status.
-	contextBuf := bytes.NewBuffer(splitBinaryCarrier.TracerState[:0])
-	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.TraceID)
+	err = binary.Write(buffer, binary.BigEndian, sc.raw.TraceID)
 	if err != nil {
 		return err
 	}
 
-	err = binary.Write(contextBuf, binary.BigEndian, sc.raw.SpanID)
+	err = binary.Write(buffer, binary.BigEndian, sc.raw.SpanID)
 	if err != nil {
 		return err
 	}
 
-	err = binary.Write(contextBuf, binary.BigEndian, sampledByte)
+	err = binary.Write(buffer, binary.BigEndian, sampledByte)
 	if err != nil {
 		return err
 	}
 
 	// Handle the baggage.
-	baggageBuf := bytes.NewBuffer(splitBinaryCarrier.Baggage[:0])
-	err = binary.Write(baggageBuf, binary.BigEndian, int32(len(sc.raw.Baggage)))
+	err = binary.Write(buffer, binary.BigEndian, int32(len(sc.raw.Baggage)))
 	if err != nil {
 		return err
 	}
 	for k, v := range sc.raw.Baggage {
-		if err = binary.Write(baggageBuf, binary.BigEndian, int32(len(k))); err != nil {
+		if err = binary.Write(buffer, binary.BigEndian, int32(len(k))); err != nil {
 			return err
 		}
-		baggageBuf.WriteString(k)
-		if err = binary.Write(baggageBuf, binary.BigEndian, int32(len(v))); err != nil {
+		buffer.WriteString(k)
+		if err = binary.Write(buffer, binary.BigEndian, int32(len(v))); err != nil {
 			return err
 		}
-		baggageBuf.WriteString(v)
+		buffer.WriteString(v)
 	}
 
-	splitBinaryCarrier.TracerState = contextBuf.Bytes()
-	splitBinaryCarrier.Baggage = baggageBuf.Bytes()
+	// Write out to the carrier.
+	if carrier == nil {
+		// Allocate if needed.
+		carrier = &([]byte{})
+	}
+	*carrier = buffer.Bytes()
 	return nil
 }
 
-func (p *splitBinaryPropagator) Join(
+func (p *binaryPropagator) Join(
 	operationName string,
-	carrier interface{},
+	opaqueCarrier interface{},
 ) (opentracing.Span, error) {
-	splitBinaryCarrier, ok := carrier.(*opentracing.SplitBinaryCarrier)
+	carrier, ok := opaqueCarrier.(opentracing.BinaryCarrier)
 	if !ok {
 		return nil, opentracing.ErrInvalidCarrier
 	}
-	if len(splitBinaryCarrier.TracerState) == 0 {
+	if len(*carrier) == 0 {
 		return nil, opentracing.ErrTraceNotFound
 	}
 	// Handle the trace, span ids, and sampled status.
-	contextReader := bytes.NewReader(splitBinaryCarrier.TracerState)
+	reader := bytes.NewReader(*carrier)
 	var traceID, propagatedSpanID int64
 	var sampledByte byte
 
-	if err := binary.Read(contextReader, binary.BigEndian, &traceID); err != nil {
+	if err := binary.Read(reader, binary.BigEndian, &traceID); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
-	if err := binary.Read(contextReader, binary.BigEndian, &propagatedSpanID); err != nil {
+	if err := binary.Read(reader, binary.BigEndian, &propagatedSpanID); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
-	if err := binary.Read(contextReader, binary.BigEndian, &sampledByte); err != nil {
+	if err := binary.Read(reader, binary.BigEndian, &sampledByte); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
 
 	// Handle the baggage.
-	baggageReader := bytes.NewReader(splitBinaryCarrier.Baggage)
 	var numBaggage int32
-	if err := binary.Read(baggageReader, binary.BigEndian, &numBaggage); err != nil {
+	if err := binary.Read(reader, binary.BigEndian, &numBaggage); err != nil {
 		return nil, opentracing.ErrTraceCorrupted
 	}
 	iNumBaggage := int(numBaggage)
@@ -229,20 +221,20 @@ func (p *splitBinaryPropagator) Join(
 		baggageMap = make(map[string]string, iNumBaggage)
 		var keyLen, valLen int32
 		for i := 0; i < iNumBaggage; i++ {
-			if err := binary.Read(baggageReader, binary.BigEndian, &keyLen); err != nil {
+			if err := binary.Read(reader, binary.BigEndian, &keyLen); err != nil {
 				return nil, opentracing.ErrTraceCorrupted
 			}
 			buf.Grow(int(keyLen))
-			if n, err := io.CopyN(&buf, baggageReader, int64(keyLen)); err != nil || int32(n) != keyLen {
+			if n, err := io.CopyN(&buf, reader, int64(keyLen)); err != nil || int32(n) != keyLen {
 				return nil, opentracing.ErrTraceCorrupted
 			}
 			key := buf.String()
 			buf.Reset()
 
-			if err := binary.Read(baggageReader, binary.BigEndian, &valLen); err != nil {
+			if err := binary.Read(reader, binary.BigEndian, &valLen); err != nil {
 				return nil, opentracing.ErrTraceCorrupted
 			}
-			if n, err := io.CopyN(&buf, baggageReader, int64(valLen)); err != nil || int32(n) != valLen {
+			if n, err := io.CopyN(&buf, reader, int64(valLen)); err != nil || int32(n) != valLen {
 				return nil, opentracing.ErrTraceCorrupted
 			}
 			baggageMap[key] = buf.String()
@@ -269,58 +261,47 @@ func (p *splitBinaryPropagator) Join(
 	), nil
 }
 
-const (
-	tracerStateHeaderName  = "Tracer-State"
-	traceBaggageHeaderName = "Trace-Baggage"
-)
-
 func (p *goHTTPPropagator) Inject(
 	sp opentracing.Span,
-	carrier interface{},
+	opaqueCarrier interface{},
 ) error {
-	// Defer to SplitBinary for the real work.
-	splitBinaryCarrier := opentracing.NewSplitBinaryCarrier()
-	if err := p.splitBinaryPropagator.Inject(sp, splitBinaryCarrier); err != nil {
-		return err
+	headerCarrier, ok := opaqueCarrier.(http.Header)
+	if !ok {
+		return opentracing.ErrInvalidCarrier
 	}
 
-	// Encode into the HTTP header as two base64 strings.
-	header := carrier.(http.Header)
-	header.Add(tracerStateHeaderName, base64.StdEncoding.EncodeToString(
-		splitBinaryCarrier.TracerState))
-	header.Add(traceBaggageHeaderName, base64.StdEncoding.EncodeToString(
-		splitBinaryCarrier.Baggage))
+	// Defer to TextMapCarrier for the real work.
+	textMapCarrier := opentracing.TextMapCarrier{}
+	if err := p.textMapPropagator.Inject(sp, textMapCarrier); err != nil {
+		return err
+	}
+	// Encode as URL-escaped HTTP header vals.
+	for headerKey, headerVal := range textMapCarrier {
+		headerCarrier.Add(headerKey, url.QueryEscape(headerVal))
+	}
 
 	return nil
 }
 
 func (p *goHTTPPropagator) Join(
 	operationName string,
-	carrier interface{},
+	opaqueCarrier interface{},
 ) (opentracing.Span, error) {
-	// Decode the two base64-encoded data blobs from the HTTP header.
-	header := carrier.(http.Header)
-	tracerStateBase64, found := header[http.CanonicalHeaderKey(tracerStateHeaderName)]
-	if !found || len(tracerStateBase64) == 0 {
-		return nil, opentracing.ErrTraceNotFound
-	}
-	traceBaggageBase64, found := header[http.CanonicalHeaderKey(traceBaggageHeaderName)]
-	if !found || len(traceBaggageBase64) == 0 {
-		return nil, opentracing.ErrTraceNotFound
-	}
-	tracerStateBinary, err := base64.StdEncoding.DecodeString(tracerStateBase64[0])
-	if err != nil {
-		return nil, opentracing.ErrTraceCorrupted
-	}
-	traceBaggageBinary, err := base64.StdEncoding.DecodeString(traceBaggageBase64[0])
-	if err != nil {
-		return nil, opentracing.ErrTraceCorrupted
+	headerCarrier, ok := opaqueCarrier.(http.Header)
+	if !ok {
+		return nil, opentracing.ErrInvalidCarrier
 	}
 
-	// Defer to SplitBinary for the real work.
-	splitBinaryCarrier := &opentracing.SplitBinaryCarrier{
-		TracerState: tracerStateBinary,
-		Baggage:     traceBaggageBinary,
+	// Build a TextMapCarrier from the string->[]string http.Header map.
+	textCarrier := make(opentracing.TextMapCarrier, len(headerCarrier))
+	for k, vals := range headerCarrier {
+		// We don't know what to do with anything beyond slice item v[0]:
+		unescaped, err := url.QueryUnescape(vals[0])
+		if err != nil {
+			continue
+		}
+		textCarrier[k] = unescaped
 	}
-	return p.splitBinaryPropagator.Join(operationName, splitBinaryCarrier)
+	// Defer to textMapCarrier for the rest of the work.
+	return p.textMapPropagator.Join(operationName, textCarrier)
 }

--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -43,13 +43,13 @@ func (p *textMapPropagator) Inject(
 	if !ok {
 		return opentracing.ErrInvalidCarrier
 	}
-	carrier.Add(fieldNameTraceID, strconv.FormatInt(sc.raw.TraceID, 16))
-	carrier.Add(fieldNameSpanID, strconv.FormatInt(sc.raw.SpanID, 16))
-	carrier.Add(fieldNameSampled, strconv.FormatBool(sc.raw.Sampled))
+	carrier.Set(fieldNameTraceID, strconv.FormatInt(sc.raw.TraceID, 16))
+	carrier.Set(fieldNameSpanID, strconv.FormatInt(sc.raw.SpanID, 16))
+	carrier.Set(fieldNameSampled, strconv.FormatBool(sc.raw.Sampled))
 
 	sc.Lock()
 	for k, v := range sc.raw.Baggage {
-		carrier.Add(prefixBaggage+k, v)
+		carrier.Set(prefixBaggage+k, v)
 	}
 	sc.Unlock()
 	return nil
@@ -68,7 +68,7 @@ func (p *textMapPropagator) Join(
 	var sampled bool
 	var err error
 	decodedBaggage := make(map[string]string)
-	err = carrier.ReadAll(func(k, v string) error {
+	err = carrier.ForeachKey(func(k, v string) error {
 		switch strings.ToLower(k) {
 		case fieldNameTraceID:
 			traceID, err = strconv.ParseInt(v, 16, 64)

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -48,8 +48,8 @@ func TestSpanPropagator(t *testing.T) {
 		typ, carrier interface{}
 	}{
 		{basictracer.Delegator, basictracer.DelegatingCarrier(&verbatimCarrier{b: map[string]string{}})},
-		{opentracing.SplitBinary, opentracing.NewSplitBinaryCarrier()},
-		{opentracing.SplitText, opentracing.NewSplitTextCarrier()},
+		{opentracing.Binary, opentracing.BinaryCarrier(&[]byte{})},
+		{opentracing.TextMap, opentracing.TextMapCarrier{}},
 		{opentracing.GoHTTPHeader, http.Header{}},
 	}
 

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -45,13 +45,13 @@ func TestSpanPropagator(t *testing.T) {
 	sp := tracer.StartSpan(op)
 	sp.SetBaggageItem("foo", "bar")
 
+	tmc := opentracing.HTTPHeaderTextMapCarrier(http.Header{})
 	tests := []struct {
 		typ, carrier interface{}
 	}{
 		{basictracer.Delegator, basictracer.DelegatingCarrier(&verbatimCarrier{b: map[string]string{}})},
-		{opentracing.Binary, opentracing.BinaryCarrier(&bytes.Buffer{})},
-		{opentracing.TextMap, opentracing.HTTPHeaderTextMapCarrier{http.Header{}}},
-		{opentracing.GoHTTPHeader, http.Header{}},
+		{opentracing.Binary, &bytes.Buffer{}},
+		{opentracing.TextMap, tmc},
 	}
 
 	for i, test := range tests {

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -1,6 +1,7 @@
 package basictracer_test
 
 import (
+	"bytes"
 	"net/http"
 	"reflect"
 	"testing"
@@ -48,8 +49,8 @@ func TestSpanPropagator(t *testing.T) {
 		typ, carrier interface{}
 	}{
 		{basictracer.Delegator, basictracer.DelegatingCarrier(&verbatimCarrier{b: map[string]string{}})},
-		{opentracing.Binary, opentracing.BinaryCarrier(&[]byte{})},
-		{opentracing.TextMap, opentracing.TextMapCarrier{}},
+		{opentracing.Binary, opentracing.BinaryCarrier(&bytes.Buffer{})},
+		{opentracing.TextMap, opentracing.HTTPHeaderTextMapCarrier{http.Header{}}},
 		{opentracing.GoHTTPHeader, http.Header{}},
 	}
 

--- a/tracer.go
+++ b/tracer.go
@@ -79,9 +79,9 @@ func DefaultOptions() Options {
 // NewWithOptions creates a customized Tracer.
 func NewWithOptions(opts Options) opentracing.Tracer {
 	rval := &tracerImpl{Options: opts}
-	rval.textPropagator = &splitTextPropagator{rval}
-	rval.binaryPropagator = &splitBinaryPropagator{rval}
-	rval.goHTTPPropagator = &goHTTPPropagator{rval.binaryPropagator}
+	rval.textPropagator = &textMapPropagator{rval}
+	rval.binaryPropagator = &binaryPropagator{rval}
+	rval.goHTTPPropagator = &goHTTPPropagator{rval.textPropagator}
 	rval.accessorPropagator = &accessorPropagator{rval}
 	return rval
 }
@@ -99,8 +99,8 @@ func New(recorder SpanRecorder) opentracing.Tracer {
 // Implements the `Tracer` interface.
 type tracerImpl struct {
 	Options
-	textPropagator     *splitTextPropagator
-	binaryPropagator   *splitBinaryPropagator
+	textPropagator     *textMapPropagator
+	binaryPropagator   *binaryPropagator
 	goHTTPPropagator   *goHTTPPropagator
 	accessorPropagator *accessorPropagator
 }
@@ -189,9 +189,9 @@ var Delegator delegatorType
 
 func (t *tracerImpl) Inject(sp opentracing.Span, format interface{}, carrier interface{}) error {
 	switch format {
-	case opentracing.SplitText:
+	case opentracing.TextMap:
 		return t.textPropagator.Inject(sp, carrier)
-	case opentracing.SplitBinary:
+	case opentracing.Binary:
 		return t.binaryPropagator.Inject(sp, carrier)
 	case opentracing.GoHTTPHeader:
 		return t.goHTTPPropagator.Inject(sp, carrier)
@@ -204,9 +204,9 @@ func (t *tracerImpl) Inject(sp opentracing.Span, format interface{}, carrier int
 
 func (t *tracerImpl) Join(operationName string, format interface{}, carrier interface{}) (opentracing.Span, error) {
 	switch format {
-	case opentracing.SplitText:
+	case opentracing.TextMap:
 		return t.textPropagator.Join(operationName, carrier)
-	case opentracing.SplitBinary:
+	case opentracing.Binary:
 		return t.binaryPropagator.Join(operationName, carrier)
 	case opentracing.GoHTTPHeader:
 		return t.goHTTPPropagator.Join(operationName, carrier)

--- a/tracer.go
+++ b/tracer.go
@@ -81,7 +81,6 @@ func NewWithOptions(opts Options) opentracing.Tracer {
 	rval := &tracerImpl{Options: opts}
 	rval.textPropagator = &textMapPropagator{rval}
 	rval.binaryPropagator = &binaryPropagator{rval}
-	rval.goHTTPPropagator = &goHTTPPropagator{rval.textPropagator}
 	rval.accessorPropagator = &accessorPropagator{rval}
 	return rval
 }
@@ -101,7 +100,6 @@ type tracerImpl struct {
 	Options
 	textPropagator     *textMapPropagator
 	binaryPropagator   *binaryPropagator
-	goHTTPPropagator   *goHTTPPropagator
 	accessorPropagator *accessorPropagator
 }
 
@@ -193,8 +191,6 @@ func (t *tracerImpl) Inject(sp opentracing.Span, format interface{}, carrier int
 		return t.textPropagator.Inject(sp, carrier)
 	case opentracing.Binary:
 		return t.binaryPropagator.Inject(sp, carrier)
-	case opentracing.GoHTTPHeader:
-		return t.goHTTPPropagator.Inject(sp, carrier)
 	}
 	if _, ok := format.(delegatorType); ok {
 		return t.accessorPropagator.Inject(sp, carrier)
@@ -208,8 +204,6 @@ func (t *tracerImpl) Join(operationName string, format interface{}, carrier inte
 		return t.textPropagator.Join(operationName, carrier)
 	case opentracing.Binary:
 		return t.binaryPropagator.Join(operationName, carrier)
-	case opentracing.GoHTTPHeader:
-		return t.goHTTPPropagator.Join(operationName, carrier)
 	}
 	if _, ok := format.(delegatorType); ok {
 		return t.accessorPropagator.Join(operationName, carrier)


### PR DESCRIPTION
Per https://github.com/opentracing/opentracing.github.io/issues/73 and https://github.com/opentracing/opentracing-go/pull/74...


Tests still pass given the ot-go changes:

```
$ make test
go test -v -race -cover ./...
=== RUN   TestDebugAssertSingleGoroutine
--- PASS: TestDebugAssertSingleGoroutine (0.00s)
=== RUN   TestDebugAssertUseAfterFinish
--- PASS: TestDebugAssertUseAfterFinish (0.00s)
=== RUN   TestConcurrentUsage
--- PASS: TestConcurrentUsage (0.02s)
=== RUN   TestInMemoryRecorderSpans
--- PASS: TestInMemoryRecorderSpans (0.00s)
=== RUN   TestSpanPropagator
--- PASS: TestSpanPropagator (0.00s)
PASS
coverage: 79.3% of statements
ok  	github.com/opentracing/basictracer-go	1.489s	coverage: 79.3% of statements
?   	github.com/opentracing/basictracer-go/examples	[no test files]
?   	github.com/opentracing/basictracer-go/examples/dapperish	[no test files]
```