### PR TITLE
Fix SIGSEGV due to incorrect usage of sync.Pool

### DIFF
--- a/tracer.go
+++ b/tracer.go
@@ -1,7 +1,6 @@
 package basictracer
 
 import (
-	"sync"
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
@@ -79,12 +78,7 @@ func DefaultOptions() Options {
 
 // NewWithOptions creates a customized Tracer.
 func NewWithOptions(opts Options) opentracing.Tracer {
-	rval := &tracerImpl{
-		Options: opts,
-		spanPool: sync.Pool{New: func() interface{} {
-			return &spanImpl{}
-		}},
-	}
+	rval := &tracerImpl{Options: opts}
 	rval.textPropagator = &splitTextPropagator{rval}
 	rval.binaryPropagator = &splitBinaryPropagator{rval}
 	rval.goHTTPPropagator = &goHTTPPropagator{rval.binaryPropagator}
@@ -105,7 +99,6 @@ func New(recorder SpanRecorder) opentracing.Tracer {
 // Implements the `Tracer` interface.
 type tracerImpl struct {
 	Options
-	spanPool           sync.Pool
 	textPropagator     *splitTextPropagator
 	binaryPropagator   *splitBinaryPropagator
 	goHTTPPropagator   *goHTTPPropagator
@@ -122,7 +115,7 @@ func (t *tracerImpl) StartSpan(
 }
 
 func (t *tracerImpl) getSpan() *spanImpl {
-	sp := t.spanPool.Get().(*spanImpl)
+	sp := spanPool.Get().(*spanImpl)
 	sp.reset()
 	return sp
 }


### PR DESCRIPTION
We kept a `sync.Pool` on `*tracerImpl` and actually ended up copying it by
value in `Finish()` when `DebugAssertUseAfterFinish` was active.
Doing so leads to spurious obscure errors:

https://github.com/cockroachdb/cockroach/issues/5311

The minimal fix would have been changing sync.Pool to a pointer type, but at this
point it seems safer to use a package-global `*sync.Pool` to avoid regression.

Clean up a bug which left a locked span in the pool when failing a debug
assertion (this deadlocked tests after switching to the global pool).