### PR TITLE
Delete no longer used goHTTPPropagator

### DIFF
--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -17,9 +17,6 @@ type textMapPropagator struct {
 type binaryPropagator struct {
 	tracer *tracerImpl
 }
-type goHTTPPropagator struct {
-	*textMapPropagator
-}
 
 const (
 	prefixTracerState = "ot-tracer-"


### PR DESCRIPTION
`goHTTPPropagator` is no longer used nor needed now due to #15.