### PR TITLE
Expose details for basictracer spans / tracers

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -26,7 +26,7 @@ func (s *spanImpl) maybeAssertSanityLocked() {
 			msg: fmt.Sprintf("span used after Finish()"),
 		})
 	}
-	if s.tracer.Options.DebugAssertSingleGoroutine {
+	if s.tracer.options.DebugAssertSingleGoroutine {
 		startID := curGoroutineID()
 		curID, ok := s.raw.Tags[debugGoroutineIDTag].(uint64)
 		if !ok {


### PR DESCRIPTION
This allows basictracer implementations to extract detail (Context, Operation, Start) from spans at runtime and to retrieve the global Recorder implementation.