### PR TITLE
RFC: Add InMemoryCarrier

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -128,8 +128,8 @@ func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int)
 		carrier = opentracing.HTTPHeaderTextMapCarrier(http.Header{})
 	case opentracing.Binary:
 		carrier = &bytes.Buffer{}
-	case opentracing.InMemory:
-		carrier = &opentracing.InMemoryCarrier{}
+	case InMemory:
+		carrier = &InMemoryCarrier{}
 	default:
 		b.Fatalf("unhandled format %d", format)
 	}
@@ -173,11 +173,11 @@ func BenchmarkInject_Binary_100BaggageItems(b *testing.B) {
 }
 
 func BenchmarkInject_InMemory_Empty(b *testing.B) {
-	benchmarkInject(b, opentracing.InMemory, 0)
+	benchmarkInject(b, InMemory, 0)
 }
 
 func BenchmarkInject_InMemory_100BaggageItems(b *testing.B) {
-	benchmarkInject(b, opentracing.InMemory, 100)
+	benchmarkInject(b, InMemory, 100)
 }
 
 func BenchmarkJoin_TextMap_Empty(b *testing.B) {

--- a/bench_test.go
+++ b/bench_test.go
@@ -103,6 +103,8 @@ func benchmarkInject(b *testing.B, format opentracing.BuiltinFormat, numItems in
 		carrier = opentracing.HTTPHeaderTextMapCarrier(http.Header{})
 	case opentracing.Binary:
 		carrier = &bytes.Buffer{}
+	case InMemory:
+		carrier = &InMemoryCarrier{}
 	default:
 		b.Fatalf("unhandled format %d", format)
 	}
@@ -126,6 +128,8 @@ func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int)
 		carrier = opentracing.HTTPHeaderTextMapCarrier(http.Header{})
 	case opentracing.Binary:
 		carrier = &bytes.Buffer{}
+	case opentracing.InMemory:
+		carrier = &opentracing.InMemoryCarrier{}
 	default:
 		b.Fatalf("unhandled format %d", format)
 	}
@@ -168,6 +172,14 @@ func BenchmarkInject_Binary_100BaggageItems(b *testing.B) {
 	benchmarkInject(b, opentracing.Binary, 100)
 }
 
+func BenchmarkInject_InMemory_Empty(b *testing.B) {
+	benchmarkInject(b, opentracing.InMemory, 0)
+}
+
+func BenchmarkInject_InMemory_100BaggageItems(b *testing.B) {
+	benchmarkInject(b, opentracing.InMemory, 100)
+}
+
 func BenchmarkJoin_TextMap_Empty(b *testing.B) {
 	benchmarkJoin(b, opentracing.TextMap, 0)
 }
@@ -182,4 +194,12 @@ func BenchmarkJoin_Binary_Empty(b *testing.B) {
 
 func BenchmarkJoin_Binary_100BaggageItems(b *testing.B) {
 	benchmarkJoin(b, opentracing.Binary, 100)
+}
+
+func BenchmarkJoin_InMemory_Empty(b *testing.B) {
+	benchmarkJoin(b, InMemory, 0)
+}
+
+func BenchmarkJoin_InMemory_100BaggageItems(b *testing.B) {
+	benchmarkJoin(b, InMemory, 100)
 }

--- a/context.go
+++ b/context.go
@@ -13,4 +13,7 @@ type Context struct {
 
 	// Whether the trace is sampled.
 	Sampled bool
+
+	// The span's associated baggage.
+	Baggage map[string]string // initialized on first use
 }

--- a/propagation.go
+++ b/propagation.go
@@ -6,6 +6,23 @@ import (
 	opentracing "github.com/opentracing/opentracing-go"
 )
 
+const (
+	// InMemory stores a copy of a Span's state.
+	//
+	// Useful for passing along Span information across goroutines without
+	// actually passing a live Span.
+	// NOTE: This would go into the opentracing-go package. The constant number
+	// is abritrary to prevent any classes with the OT consts.
+	InMemory = 10
+)
+
+// InMemoryCarrier holds a copy of a Span's state. The underyling value can be
+// of any arbritrary type. There is no expectation for interopability between
+// different languages.
+type InMemoryCarrier struct {
+	TracerState interface{}
+}
+
 type accessorPropagator struct {
 	tracer *tracerImpl
 }

--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -46,7 +46,7 @@ func (p *textMapPropagator) Inject(
 	carrier.Set(fieldNameSampled, strconv.FormatBool(sc.raw.Sampled))
 
 	sc.Lock()
-	for k, v := range sc.raw.Baggage {
+	for k, v := range sc.raw.Context.Baggage {
 		carrier.Set(prefixBaggage+k, v)
 	}
 	sc.Unlock()
@@ -111,8 +111,8 @@ func (p *textMapPropagator) Join(
 			SpanID:       randomID(),
 			ParentSpanID: propagatedSpanID,
 			Sampled:      sampled,
+			Baggage:      decodedBaggage,
 		},
-		Baggage: decodedBaggage,
 	}
 
 	return p.tracer.startSpanInternal(
@@ -140,7 +140,7 @@ func (p *binaryPropagator) Inject(
 	state.TraceId = sc.raw.TraceID
 	state.SpanId = sc.raw.SpanID
 	state.Sampled = sc.raw.Sampled
-	state.BaggageItems = sc.raw.Baggage
+	state.BaggageItems = sc.raw.Context.Baggage
 
 	b, err := proto.Marshal(&state)
 	if err != nil {

--- a/propagation_ot.go
+++ b/propagation_ot.go
@@ -18,6 +18,9 @@ type textMapPropagator struct {
 type binaryPropagator struct {
 	tracer *tracerImpl
 }
+type inMemoryPropagator struct {
+	tracer *tracerImpl
+}
 
 const (
 	prefixTracerState = "ot-tracer-"
@@ -198,6 +201,67 @@ func (p *binaryPropagator) Join(
 	}
 
 	sp.raw.Baggage = ctx.BaggageItems
+
+	return p.tracer.startSpanInternal(
+		sp,
+		operationName,
+		time.Now(),
+		nil,
+	), nil
+}
+
+func (p *inMemoryPropagator) Inject(
+	sp opentracing.Span,
+	carrier interface{},
+) error {
+	s, ok := sp.(*spanImpl)
+	if !ok {
+		return opentracing.ErrInvalidSpan
+	}
+
+	inmem, ok := carrier.(*InMemoryCarrier)
+	if !ok {
+		return opentracing.ErrInvalidCarrier
+	}
+	ctx := Context{
+		TraceID:      s.raw.Context.TraceID,
+		SpanID:       s.raw.Context.SpanID,
+		ParentSpanID: s.raw.Context.ParentSpanID,
+		Sampled:      s.raw.Context.Sampled,
+	}
+	s.Lock()
+	ctx.Baggage = make(map[string]string, len(s.raw.Context.Baggage))
+	for k, v := range s.raw.Context.Baggage {
+		ctx.Baggage[k] = v
+	}
+	s.Unlock()
+	inmem.TracerState = ctx
+	return nil
+}
+
+func (p *inMemoryPropagator) Join(
+	operationName string,
+	carrier interface{},
+) (opentracing.Span, error) {
+	inMemCarrier, ok := carrier.(*InMemoryCarrier)
+	if !ok {
+		return nil, opentracing.ErrInvalidCarrier
+	}
+	ctx, ok := inMemCarrier.TracerState.(Context)
+	if !ok {
+		return nil, opentracing.ErrInvalidCarrier
+	}
+
+	sp := p.tracer.getSpan()
+	sp.raw = RawSpan{
+		Context: Context{
+			TraceID:      ctx.TraceID,
+			SpanID:       randomID(),
+			ParentSpanID: ctx.SpanID,
+			Sampled:      ctx.Sampled,
+			Baggage:      ctx.Baggage,
+		},
+	}
 
 	return p.tracer.startSpanInternal(
 		sp,

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -14,27 +14,28 @@ import (
 
 type verbatimCarrier struct {
 	basictracer.Context
-	b map[string]string
 }
 
 var _ basictracer.DelegatingCarrier = &verbatimCarrier{}
 
 func (vc *verbatimCarrier) SetBaggageItem(k, v string) {
-	vc.b[k] = v
+	vc.Baggage[k] = v
 }
 
 func (vc *verbatimCarrier) GetBaggage(f func(string, string)) {
-	for k, v := range vc.b {
+	for k, v := range vc.Baggage {
 		f(k, v)
 	}
 }
 
 func (vc *verbatimCarrier) SetState(tID, sID uint64, sampled bool) {
-	vc.Context = basictracer.Context{TraceID: tID, SpanID: sID, Sampled: sampled}
+	vc.TraceID = tID
+	vc.SpanID = sID
+	vc.Sampled = sampled
 }
 
 func (vc *verbatimCarrier) State() (traceID, spanID uint64, sampled bool) {
-	return vc.Context.TraceID, vc.Context.SpanID, vc.Context.Sampled
+	return vc.TraceID, vc.SpanID, vc.Sampled
 }
 
 func TestSpanPropagator(t *testing.T) {
@@ -49,7 +50,7 @@ func TestSpanPropagator(t *testing.T) {
 	tests := []struct {
 		typ, carrier interface{}
 	}{
-		{basictracer.Delegator, basictracer.DelegatingCarrier(&verbatimCarrier{b: map[string]string{}})},
+		{basictracer.Delegator, basictracer.DelegatingCarrier(&verbatimCarrier{Context: basictracer.Context{Baggage: map[string]string{}}})},
 		{opentracing.Binary, &bytes.Buffer{}},
 		{opentracing.TextMap, tmc},
 	}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -53,6 +53,7 @@ func TestSpanPropagator(t *testing.T) {
 		{basictracer.Delegator, basictracer.DelegatingCarrier(&verbatimCarrier{Context: basictracer.Context{Baggage: map[string]string{}}})},
 		{opentracing.Binary, &bytes.Buffer{}},
 		{opentracing.TextMap, tmc},
+		{opentracing.InMemory, &basictracer.InMemoryCarrier{}},
 	}
 
 	for i, test := range tests {

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -53,7 +53,7 @@ func TestSpanPropagator(t *testing.T) {
 		{basictracer.Delegator, basictracer.DelegatingCarrier(&verbatimCarrier{Context: basictracer.Context{Baggage: map[string]string{}}})},
 		{opentracing.Binary, &bytes.Buffer{}},
 		{opentracing.TextMap, tmc},
-		{opentracing.InMemory, &basictracer.InMemoryCarrier{}},
+		{basictracer.InMemory, &basictracer.InMemoryCarrier{}},
 	}
 
 	for i, test := range tests {

--- a/raw.go
+++ b/raw.go
@@ -27,7 +27,4 @@ type RawSpan struct {
 
 	// The span's "microlog".
 	Logs []opentracing.LogData
-
-	// The span's associated baggage.
-	Baggage map[string]string // initialized on first use
 }

--- a/span.go
+++ b/span.go
@@ -44,11 +44,11 @@ func (s *spanImpl) reset() {
 	// (the recorder) needs to make sure that they're not holding on to the
 	// baggage or logs when they return (i.e. they need to copy if they care):
 	//
-	// logs, baggage := s.raw.Logs[:0], s.raw.Baggage
+	// logs, baggage := s.raw.Logs[:0], s.raw.Context.Baggage
 	// for k := range baggage {
 	// 	delete(baggage, k)
 	// }
-	// s.raw.Logs, s.raw.Baggage = logs, baggage
+	// s.raw.Logs, s.raw.Context.Baggage = logs, baggage
 	//
 	// That's likely too much to ask for. But there is some magic we should
 	// be able to do with `runtime.SetFinalizer` to reclaim that memory into
@@ -157,10 +157,10 @@ func (s *spanImpl) SetBaggageItem(restrictedKey, val string) opentracing.Span {
 		return s
 	}
 
-	if s.raw.Baggage == nil {
-		s.raw.Baggage = make(map[string]string)
+	if s.raw.Context.Baggage == nil {
+		s.raw.Context.Baggage = make(map[string]string)
 	}
-	s.raw.Baggage[canonicalKey] = val
+	s.raw.Context.Baggage[canonicalKey] = val
 	return s
 }
 
@@ -173,7 +173,7 @@ func (s *spanImpl) BaggageItem(restrictedKey string) string {
 	s.Lock()
 	defer s.Unlock()
 
-	return s.raw.Baggage[canonicalKey]
+	return s.raw.Context.Baggage[canonicalKey]
 }
 
 func (s *spanImpl) Tracer() opentracing.Tracer {

--- a/tracer.go
+++ b/tracer.go
@@ -91,6 +91,7 @@ func NewWithOptions(opts Options) opentracing.Tracer {
 	rval.textPropagator = &textMapPropagator{rval}
 	rval.binaryPropagator = &binaryPropagator{rval}
 	rval.accessorPropagator = &accessorPropagator{rval}
+	rval.inMemoryPropagator = &inMemoryPropagator{rval}
 	return rval
 }
 
@@ -110,6 +111,7 @@ type tracerImpl struct {
 	textPropagator     *textMapPropagator
 	binaryPropagator   *binaryPropagator
 	accessorPropagator *accessorPropagator
+	inMemoryPropagator *inMemoryPropagator
 }
 
 func (t *tracerImpl) StartSpan(
@@ -200,6 +202,8 @@ func (t *tracerImpl) Inject(sp opentracing.Span, format interface{}, carrier int
 		return t.textPropagator.Inject(sp, carrier)
 	case opentracing.Binary:
 		return t.binaryPropagator.Inject(sp, carrier)
+	case opentracing.InMemory:
+		return t.inMemoryPropagator.Inject(sp, carrier)
 	}
 	if _, ok := format.(delegatorType); ok {
 		return t.accessorPropagator.Inject(sp, carrier)
@@ -213,6 +217,8 @@ func (t *tracerImpl) Join(operationName string, format interface{}, carrier inte
 		return t.textPropagator.Join(operationName, carrier)
 	case opentracing.Binary:
 		return t.binaryPropagator.Join(operationName, carrier)
+	case opentracing.InMemory:
+		return t.inMemoryPropagator.Join(operationName, carrier)
 	}
 	if _, ok := format.(delegatorType); ok {
 		return t.accessorPropagator.Join(operationName, carrier)

--- a/tracer.go
+++ b/tracer.go
@@ -202,7 +202,7 @@ func (t *tracerImpl) Inject(sp opentracing.Span, format interface{}, carrier int
 		return t.textPropagator.Inject(sp, carrier)
 	case opentracing.Binary:
 		return t.binaryPropagator.Inject(sp, carrier)
-	case opentracing.InMemory:
+	case InMemory:
 		return t.inMemoryPropagator.Inject(sp, carrier)
 	}
 	if _, ok := format.(delegatorType); ok {
@@ -217,7 +217,7 @@ func (t *tracerImpl) Join(operationName string, format interface{}, carrier inte
 		return t.textPropagator.Join(operationName, carrier)
 	case opentracing.Binary:
 		return t.binaryPropagator.Join(operationName, carrier)
-	case opentracing.InMemory:
+	case InMemory:
 		return t.inMemoryPropagator.Join(operationName, carrier)
 	}
 	if _, ok := format.(delegatorType); ok {


### PR DESCRIPTION
**DO NOT MERGE**

Fixes http://github.com/opentracing/basictracer-go/issues/23

InMemoryCarrier carries a copy of the span's information for use after a span finishes. 