### PR TITLE
Move net/trace event example into example folder

### DIFF
--- a/events/event_nettrace.go
+++ b/events/event_nettrace.go
@@ -1,18 +1,21 @@
-package basictracer
+package events
 
-import "golang.org/x/net/trace"
+import (
+	"github.com/opentracing/basictracer-go"
+	"golang.org/x/net/trace"
+)
 
 // NetTraceIntegrator can be passed into a basictracer as NewSpanEventListener
 // and causes all traces to be registered with the net/trace endpoint.
-var NetTraceIntegrator = func() func(SpanEvent) {
+var NetTraceIntegrator = func() func(basictracer.SpanEvent) {
 	var tr trace.Trace
-	return func(e SpanEvent) {
+	return func(e basictracer.SpanEvent) {
 		switch t := e.(type) {
-		case EventCreate:
+		case basictracer.EventCreate:
 			tr = trace.New("tracing", t.OperationName)
-		case EventFinish:
+		case basictracer.EventFinish:
 			tr.Finish()
-		case EventLog:
+		case basictracer.EventLog:
 			if t.Payload != nil {
 				tr.LazyPrintf("%s (payload %v)", t.Event, t.Payload)
 			} else {


### PR DESCRIPTION
I was running into the issue that if a project already used net/trace,
there would be a double initialization issue when trying to use
basictracer despite not using the integrator.

cc @tschottdorf since you use this at cockroach