### PR TITLE
Add option to disable the use of the span pool

### DIFF
--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -11,6 +11,7 @@ const op = "test"
 
 func TestDebugAssertSingleGoroutine(t *testing.T) {
 	opts := DefaultOptions()
+	opts.EnableSpanPool = true
 	opts.Recorder = NewInMemoryRecorder()
 	opts.DebugAssertSingleGoroutine = true
 	tracer := NewWithOptions(opts)
@@ -35,6 +36,7 @@ func TestDebugAssertSingleGoroutine(t *testing.T) {
 
 func TestDebugAssertUseAfterFinish(t *testing.T) {
 	opts := DefaultOptions()
+	opts.EnableSpanPool = true
 	opts.Recorder = NewInMemoryRecorder()
 	opts.DebugAssertUseAfterFinish = true
 	tracer := NewWithOptions(opts)
@@ -66,6 +68,7 @@ func TestDebugAssertUseAfterFinish(t *testing.T) {
 
 func TestConcurrentUsage(t *testing.T) {
 	opts := DefaultOptions()
+	opts.EnableSpanPool = true
 	var cr CountingRecorder
 	opts.Recorder = &cr
 	opts.DebugAssertSingleGoroutine = true
@@ -95,7 +98,6 @@ func TestConcurrentUsage(t *testing.T) {
 
 func TestDisableSpanPool(t *testing.T) {
 	opts := DefaultOptions()
-	opts.DisableSpanPool = true
 	var cr CountingRecorder
 	opts.Recorder = &cr
 	tracer := NewWithOptions(opts)

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -92,3 +92,20 @@ func TestConcurrentUsage(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestDisableSpanPool(t *testing.T) {
+	opts := DefaultOptions()
+	opts.DisableSpanPool = true
+	var cr CountingRecorder
+	opts.Recorder = &cr
+	tracer := NewWithOptions(opts)
+
+	parent := tracer.StartSpan("parent")
+	parent.Finish()
+	// This shound't panic.
+	child := tracer.StartSpanWithOptions(opentracing.StartSpanOptions{
+		Parent:        parent,
+		OperationName: "child",
+	})
+	child.Finish()
+}

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -104,7 +104,7 @@ func TestDisableSpanPool(t *testing.T) {
 
 	parent := tracer.StartSpan("parent")
 	parent.Finish()
-	// This shound't panic.
+	// This shouldn't panic.
 	child := tracer.StartSpanWithOptions(opentracing.StartSpanOptions{
 		Parent:        parent,
 		OperationName: "child",

--- a/span.go
+++ b/span.go
@@ -137,20 +137,17 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	s.onFinish(s.raw)
 	s.tracer.options.Recorder.RecordSpan(s.raw)
 
-	// Last chance to get options before the span is possibly reset.
-	poolDisabled := s.tracer.options.DisableSpanPool
-
+	// Last chance to get options before the span is possbily reset.
+	poolEnabled := s.tracer.options.EnableSpanPool
 	if s.tracer.options.DebugAssertUseAfterFinish {
 		// This makes it much more likely to catch a panic on any subsequent
 		// operation since s.tracer is accessed on every call to `Lock`.
 		s.reset()
 	}
 
-	// Don't put it in the pool.
-	if poolDisabled {
-		return
+	if poolEnabled {
+		spanPool.Put(s)
 	}
-	spanPool.Put(s)
 }
 
 func (s *spanImpl) SetBaggageItem(restrictedKey, val string) opentracing.Span {

--- a/span.go
+++ b/span.go
@@ -136,10 +136,19 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 
 	s.onFinish(s.raw)
 	s.tracer.options.Recorder.RecordSpan(s.raw)
+
+	// Last chance to get options before the span is possibly reset.
+	poolDisabled := s.tracer.options.DisableSpanPool
+
 	if s.tracer.options.DebugAssertUseAfterFinish {
 		// This makes it much more likely to catch a panic on any subsequent
 		// operation since s.tracer is accessed on every call to `Lock`.
 		s.reset()
+	}
+
+	// Don't put it in the pool.
+	if poolDisabled {
+		return
 	}
 	spanPool.Put(s)
 }

--- a/tracer.go
+++ b/tracer.go
@@ -73,12 +73,11 @@ type Options struct {
 	// When set, it attempts to exacerbate issues emanating from use of Spans
 	// after calling Finish by running additional assertions.
 	DebugAssertUseAfterFinish bool
-	// DisableSpanPool disables reuse of the underlying span structs.
-	// Buyer Beware, any operations called on a span after Finish is undefined
-	// behavior. The main usecase of disabling the pool is to allow the creation
-	// of children spans after Finish() has been called on the parent span.
-	// There is a performance loss when disabling the pool.
-	DisableSpanPool bool
+	// EnableSpanPool enables the use of a pool, so that the tracer reuses spans
+	// after Finish has been called on it. Adds a slight performance gain as it
+	// reduces allocations. However, if you have any use-after-finish race
+	// conditions the code may panic.
+	EnableSpanPool bool
 }
 
 // DefaultOptions returns an Options object with a 1 in 64 sampling rate and
@@ -88,7 +87,6 @@ func DefaultOptions() Options {
 	var opts Options
 	opts.ShouldSample = func(traceID uint64) bool { return traceID%64 == 0 }
 	opts.NewSpanEventListener = func() func(SpanEvent) { return nil }
-	opts.DisableSpanPool = false
 	return opts
 }
 
@@ -129,12 +127,12 @@ func (t *tracerImpl) StartSpan(
 }
 
 func (t *tracerImpl) getSpan() *spanImpl {
-	if t.options.DisableSpanPool {
-		return &spanImpl{}
+	if t.options.EnableSpanPool {
+		sp := spanPool.Get().(*spanImpl)
+		sp.reset()
+		return sp
 	}
-	sp := spanPool.Get().(*spanImpl)
-	sp.reset()
-	return sp
+	return &spanImpl{}
 }
 
 func (t *tracerImpl) StartSpanWithOptions(


### PR DESCRIPTION
DisableSpanPool disables reuse of the underlying span structs. The main use case of disabling the pool is to allow the creation of children spans after Finish() has been called on the parent span. Even if the behavior is undefined, we should allow this to happen to prevent panics from occurring in production code.

https://github.com/opentracing/basictracer-go/issues/23