### PR TITLE
Update to support opentracing.SpanContext (and References)

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -26,7 +26,7 @@ func executeOps(sp opentracing.Span, numEvent, numTag, numItems int) {
 		sp.SetTag(tags[j], nil)
 	}
 	for j := 0; j < numItems; j++ {
-		sp.SetBaggageItem(tags[j], tags[j])
+		sp.Context().SetBaggageItem(tags[j], tags[j])
 	}
 }
 
@@ -108,14 +108,14 @@ func benchmarkInject(b *testing.B, format opentracing.BuiltinFormat, numItems in
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		err := tracer.Inject(sp, format, carrier)
+		err := tracer.Inject(sp.Context(), format, carrier)
 		if err != nil {
 			b.Fatal(err)
 		}
 	}
 }
 
-func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int) {
+func benchmarkExtract(b *testing.B, format opentracing.BuiltinFormat, numItems int) {
 	var r CountingRecorder
 	tracer := New(&r)
 	sp := tracer.StartSpan("testing")
@@ -129,12 +129,12 @@ func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int)
 	default:
 		b.Fatalf("unhandled format %d", format)
 	}
-	if err := tracer.Inject(sp, format, carrier); err != nil {
+	if err := tracer.Inject(sp.Context(), format, carrier); err != nil {
 		b.Fatal(err)
 	}
 
-	// We create a new bytes.Buffer every time for tracer.Join() to keep this
-	// benchmark realistic.
+	// We create a new bytes.Buffer every time for tracer.Extract() to keep
+	// this benchmark realistic.
 	var rawBinaryBytes []byte
 	if format == opentracing.Binary {
 		rawBinaryBytes = carrier.(*bytes.Buffer).Bytes()
@@ -144,11 +144,10 @@ func benchmarkJoin(b *testing.B, format opentracing.BuiltinFormat, numItems int)
 		if format == opentracing.Binary {
 			carrier = bytes.NewBuffer(rawBinaryBytes)
 		}
-		sp, err := tracer.Join("benchmark", format, carrier)
+		_, err := tracer.Extract(format, carrier)
 		if err != nil {
 			b.Fatal(err)
 		}
-		sp.Finish() // feed back into buffer pool
 	}
 }
 
@@ -169,17 +168,17 @@ func BenchmarkInject_Binary_100BaggageItems(b *testing.B) {
 }
 
 func BenchmarkJoin_TextMap_Empty(b *testing.B) {
-	benchmarkJoin(b, opentracing.TextMap, 0)
+	benchmarkExtract(b, opentracing.TextMap, 0)
 }
 
 func BenchmarkJoin_TextMap_100BaggageItems(b *testing.B) {
-	benchmarkJoin(b, opentracing.TextMap, 100)
+	benchmarkExtract(b, opentracing.TextMap, 100)
 }
 
 func BenchmarkJoin_Binary_Empty(b *testing.B) {
-	benchmarkJoin(b, opentracing.Binary, 0)
+	benchmarkExtract(b, opentracing.Binary, 0)
 }
 
 func BenchmarkJoin_Binary_100BaggageItems(b *testing.B) {
-	benchmarkJoin(b, opentracing.Binary, 100)
+	benchmarkExtract(b, opentracing.Binary, 100)
 }

--- a/concurrency_test.go
+++ b/concurrency_test.go
@@ -83,11 +83,11 @@ func TestConcurrentUsage(t *testing.T) {
 				sp := tracer.StartSpan(op)
 				sp.LogEvent("test event")
 				sp.SetTag("foo", "bar")
-				sp.SetBaggageItem("boo", "far")
+				sp.Context().SetBaggageItem("boo", "far")
 				sp.SetOperationName("x")
-				csp := tracer.StartSpanWithOptions(opentracing.StartSpanOptions{
-					Parent: sp,
-				})
+				csp := tracer.StartSpan(
+					"csp",
+					opentracing.ChildOf(sp.Context()))
 				csp.Finish()
 				defer sp.Finish()
 			}
@@ -105,9 +105,8 @@ func TestDisableSpanPool(t *testing.T) {
 	parent := tracer.StartSpan("parent")
 	parent.Finish()
 	// This shouldn't panic.
-	child := tracer.StartSpanWithOptions(opentracing.StartSpanOptions{
-		Parent:        parent,
-		OperationName: "child",
-	})
+	child := tracer.StartSpan(
+		"child",
+		opentracing.ChildOf(parent.Context()))
 	child.Finish()
 }

--- a/context.go
+++ b/context.go
@@ -1,16 +1,62 @@
 package basictracer
 
-// Context holds the basic Span metadata.
-type Context struct {
+import (
+	"sync"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+// SpanContext holds the basic Span metadata.
+type SpanContext struct {
 	// A probabilistically unique identifier for a [multi-span] trace.
 	TraceID uint64
 
 	// A probabilistically unique identifier for a span.
 	SpanID uint64
 
-	// The SpanID of this Context's parent, or 0 if there is no parent.
-	ParentSpanID uint64
-
 	// Whether the trace is sampled.
 	Sampled bool
+
+	// The span's associated baggage.
+	baggageLock sync.Mutex
+	Baggage     map[string]string // initialized on first use
+}
+
+// BaggageItem belongs to the opentracing.SpanContext interface
+func (c *SpanContext) BaggageItem(key string) string {
+	// TODO: if we want to support onBaggage, need a pointer to the bt.Span.
+	//   s.onBaggage(canonicalKey, val)
+	//   if s.trim() {
+	//   	return s
+	//   }
+
+	c.baggageLock.Lock()
+	defer c.baggageLock.Unlock()
+
+	if c.Baggage == nil {
+		return ""
+	}
+	return c.Baggage[key]
+}
+
+// SetBaggageItem belongs to the opentracing.SpanContext interface
+func (c *SpanContext) SetBaggageItem(key, val string) opentracing.SpanContext {
+	c.baggageLock.Lock()
+	defer c.baggageLock.Unlock()
+	if c.Baggage == nil {
+		c.Baggage = make(map[string]string)
+	}
+	c.Baggage[key] = val
+	return c
+}
+
+// ForeachBaggageItem belongs to the opentracing.SpanContext interface
+func (c *SpanContext) ForeachBaggageItem(handler func(k, v string) bool) {
+	c.baggageLock.Lock()
+	defer c.baggageLock.Unlock()
+	for k, v := range c.Baggage {
+		if !handler(k, v) {
+			break
+		}
+	}
 }

--- a/examples/dapperish/trivialrecorder.go
+++ b/examples/dapperish/trivialrecorder.go
@@ -35,7 +35,7 @@ func (t *TrivialRecorder) RecordSpan(span basictracer.RawSpan) {
 	fmt.Printf(
 		"RecordSpan: %v[%v, %v us] --> %v logs. std context: %v; baggage: %v\n",
 		span.Operation, span.Start, span.Duration, len(span.Logs),
-		span.Context, span.Baggage)
+		span.SpanContext, span.Baggage)
 	for i, l := range span.Logs {
 		fmt.Printf(
 			"    log %v @ %v: %v --> %v\n", i, l.Timestamp, l.Event, reflect.TypeOf(l.Payload))

--- a/raw.go
+++ b/raw.go
@@ -10,7 +10,7 @@ import (
 type RawSpan struct {
 	// The RawSpan embeds its SpanContext. Those recording the RawSpan
 	// should also record the contents of its SpanContext.
-	SpanContext
+	*SpanContext
 
 	// The SpanID of this SpanContext's first intra-trace reference (i.e.,
 	// "parent"), or 0 if there is no parent.

--- a/raw.go
+++ b/raw.go
@@ -8,9 +8,13 @@ import (
 
 // RawSpan encapsulates all state associated with a (finished) Span.
 type RawSpan struct {
-	// The RawSpan embeds its Context. Those recording the RawSpan
-	// should also record the contents of its Context.
-	Context
+	// The RawSpan embeds its SpanContext. Those recording the RawSpan
+	// should also record the contents of its SpanContext.
+	SpanContext
+
+	// The SpanID of this SpanContext's first intra-trace reference (i.e.,
+	// "parent"), or 0 if there is no parent.
+	ParentSpanID uint64
 
 	// The name of the "operation" this span is an instance of. (Called a "span
 	// name" in some implementations)
@@ -27,7 +31,4 @@ type RawSpan struct {
 
 	// The span's "microlog".
 	Logs []opentracing.LogData
-
-	// The span's associated baggage.
-	Baggage map[string]string // initialized on first use
 }

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -12,7 +12,7 @@ func TestInMemoryRecorderSpans(t *testing.T) {
 	recorder := NewInMemoryRecorder()
 	var apiRecorder SpanRecorder = recorder
 	span := RawSpan{
-		SpanContext: SpanContext{},
+		SpanContext: &SpanContext{},
 		Operation:   "test-span",
 		Start:       time.Now(),
 		Duration:    -1,

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -12,10 +12,10 @@ func TestInMemoryRecorderSpans(t *testing.T) {
 	recorder := NewInMemoryRecorder()
 	var apiRecorder SpanRecorder = recorder
 	span := RawSpan{
-		Context:   Context{},
-		Operation: "test-span",
-		Start:     time.Now(),
-		Duration:  -1,
+		SpanContext: SpanContext{},
+		Operation:   "test-span",
+		Start:       time.Now(),
+		Duration:    -1,
 	}
 	apiRecorder.RecordSpan(span)
 	assert.Equal(t, []RawSpan{span}, recorder.GetSpans())

--- a/span.go
+++ b/span.go
@@ -1,7 +1,6 @@
 package basictracer
 
 import (
-	"fmt"
 	"sync"
 	"time"
 
@@ -14,9 +13,6 @@ import (
 // to (*opentracing.Span).Finish().
 type Span interface {
 	opentracing.Span
-
-	// Context contains trace identifiers
-	Context() Context
 
 	// Operation names the work done by this span instance
 	Operation() string
@@ -152,54 +148,12 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	}
 }
 
-func (s *spanImpl) SetBaggageItem(restrictedKey, val string) opentracing.Span {
-	canonicalKey, valid := opentracing.CanonicalizeBaggageKey(restrictedKey)
-	if !valid {
-		panic(fmt.Errorf("Invalid key: %q", restrictedKey))
-	}
-
-	s.Lock()
-	defer s.Unlock()
-	s.onBaggage(canonicalKey, val)
-	if s.trim() {
-		return s
-	}
-
-	if s.raw.Baggage == nil {
-		s.raw.Baggage = make(map[string]string)
-	}
-	s.raw.Baggage[canonicalKey] = val
-	return s
-}
-
-func (s *spanImpl) BaggageItem(restrictedKey string) string {
-	canonicalKey, valid := opentracing.CanonicalizeBaggageKey(restrictedKey)
-	if !valid {
-		panic(fmt.Errorf("Invalid key: %q", restrictedKey))
-	}
-
-	s.Lock()
-	defer s.Unlock()
-
-	return s.raw.Baggage[canonicalKey]
-}
-
-func (s *spanImpl) ForeachBaggageItem(handler func(k, v string) bool) {
-	s.Lock()
-	defer s.Unlock()
-	for k, v := range s.raw.Baggage {
-		if !handler(k, v) {
-			break
-		}
-	}
-}
-
 func (s *spanImpl) Tracer() opentracing.Tracer {
 	return s.tracer
 }
 
-func (s *spanImpl) Context() Context {
-	return s.raw.Context
+func (s *spanImpl) Context() opentracing.SpanContext {
+	return &s.raw.SpanContext
 }
 
 func (s *spanImpl) Operation() string {

--- a/span.go
+++ b/span.go
@@ -40,11 +40,11 @@ func (s *spanImpl) reset() {
 	// (the recorder) needs to make sure that they're not holding on to the
 	// baggage or logs when they return (i.e. they need to copy if they care):
 	//
-	// logs, baggage := s.raw.Logs[:0], s.raw.Baggage
-	// for k := range baggage {
-	// 	delete(baggage, k)
-	// }
-	// s.raw.Logs, s.raw.Baggage = logs, baggage
+	//     logs, baggage := s.raw.Logs[:0], s.raw.Baggage
+	//     for k := range baggage {
+	//         delete(baggage, k)
+	//     }
+	//     s.raw.Logs, s.raw.Baggage = logs, baggage
 	//
 	// That's likely too much to ask for. But there is some magic we should
 	// be able to do with `runtime.SetFinalizer` to reclaim that memory into

--- a/span.go
+++ b/span.go
@@ -51,7 +51,9 @@ func (s *spanImpl) reset() {
 	// a buffer pool when GC considers them unreachable, which should ease
 	// some of the load. Hard to say how quickly that would be in practice
 	// though.
-	s.raw = RawSpan{}
+	s.raw = RawSpan{
+		SpanContext: &SpanContext{},
+	}
 }
 
 func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
@@ -153,7 +155,7 @@ func (s *spanImpl) Tracer() opentracing.Tracer {
 }
 
 func (s *spanImpl) Context() opentracing.SpanContext {
-	return &s.raw.SpanContext
+	return s.raw.SpanContext
 }
 
 func (s *spanImpl) Operation() string {

--- a/span_test.go
+++ b/span_test.go
@@ -14,8 +14,8 @@ func TestSpan_Baggage(t *testing.T) {
 		ShouldSample: func(traceID uint64) bool { return true }, // always sample
 	})
 	span := tracer.StartSpan("x")
-	span.SetBaggageItem("x", "y")
-	assert.Equal(t, "y", span.BaggageItem("x"))
+	span.Context().SetBaggageItem("x", "y")
+	assert.Equal(t, "y", span.Context().BaggageItem("x"))
 	span.Finish()
 	spans := recorder.GetSpans()
 	assert.Equal(t, 1, len(spans))
@@ -23,17 +23,17 @@ func TestSpan_Baggage(t *testing.T) {
 
 	recorder.Reset()
 	span = tracer.StartSpan("x")
-	span.SetBaggageItem("x", "y")
+	span.Context().SetBaggageItem("x", "y")
 	baggage := make(map[string]string)
-	span.ForeachBaggageItem(func(k, v string) bool {
+	span.Context().ForeachBaggageItem(func(k, v string) bool {
 		baggage[k] = v
 		return true
 	})
 	assert.Equal(t, map[string]string{"x": "y"}, baggage)
 
-	span.SetBaggageItem("a", "b")
+	span.Context().SetBaggageItem("a", "b")
 	baggage = make(map[string]string)
-	span.ForeachBaggageItem(func(k, v string) bool {
+	span.Context().ForeachBaggageItem(func(k, v string) bool {
 		baggage[k] = v
 		return false // exit early
 	})

--- a/tracer.go
+++ b/tracer.go
@@ -118,11 +118,13 @@ type tracerImpl struct {
 
 func (t *tracerImpl) StartSpan(
 	operationName string,
+	opts ...opentracing.StartSpanOption,
 ) opentracing.Span {
-	return t.StartSpanWithOptions(
-		opentracing.StartSpanOptions{
-			OperationName: operationName,
-		})
+	sso := opentracing.StartSpanOptions{}
+	for _, o := range opts {
+		o.Apply(&sso)
+	}
+	return t.StartSpanWithOptions(operationName, sso)
 }
 
 func (t *tracerImpl) getSpan() *spanImpl {
@@ -135,6 +137,7 @@ func (t *tracerImpl) getSpan() *spanImpl {
 }
 
 func (t *tracerImpl) StartSpanWithOptions(
+	operationName string,
 	opts opentracing.StartSpanOptions,
 ) opentracing.Span {
 	// Start time.
@@ -147,31 +150,45 @@ func (t *tracerImpl) StartSpanWithOptions(
 	tags := opts.Tags
 
 	// Build the new span. This is the only allocation: We'll return this as
-	// a opentracing.Span.
+	// an opentracing.Span.
 	sp := t.getSpan()
-	if opts.Parent == nil {
+	// Look for a parent in the list of References.
+	//
+	// TODO: would be nice if basictracer did something with all
+	// References, not just the first one.
+ReferencesLoop:
+	for _, ref := range opts.References {
+		switch ref.Type {
+		case opentracing.ChildOfRef,
+			opentracing.FollowsFromRef:
+
+			refMD := ref.Referee.(*SpanContext)
+			sp.raw.TraceID = refMD.TraceID
+			sp.raw.SpanID = randomID()
+			sp.raw.ParentSpanID = refMD.SpanID
+			sp.raw.Sampled = refMD.Sampled
+
+			refMD.baggageLock.Lock()
+			if l := len(refMD.Baggage); l > 0 {
+				sp.raw.Baggage = make(map[string]string, len(refMD.Baggage))
+				for k, v := range refMD.Baggage {
+					sp.raw.Baggage[k] = v
+				}
+			}
+			refMD.baggageLock.Unlock()
+			break ReferencesLoop
+		}
+	}
+	if sp.raw.TraceID == 0 {
+		// No parent Span found; allocate new trace and span ids and determine
+		// the Sampled status.
 		sp.raw.TraceID, sp.raw.SpanID = randomID2()
 		sp.raw.Sampled = t.options.ShouldSample(sp.raw.TraceID)
-	} else {
-		pr := opts.Parent.(*spanImpl)
-		sp.raw.TraceID = pr.raw.TraceID
-		sp.raw.SpanID = randomID()
-		sp.raw.ParentSpanID = pr.raw.SpanID
-		sp.raw.Sampled = pr.raw.Sampled
-
-		pr.Lock()
-		if l := len(pr.raw.Baggage); l > 0 {
-			sp.raw.Baggage = make(map[string]string, len(pr.raw.Baggage))
-			for k, v := range pr.raw.Baggage {
-				sp.raw.Baggage[k] = v
-			}
-		}
-		pr.Unlock()
 	}
 
 	return t.startSpanInternal(
 		sp,
-		opts.OperationName,
+		operationName,
 		startTime,
 		tags,
 	)
@@ -203,28 +220,28 @@ type delegatorType struct{}
 // Delegator is the format to use for DelegatingCarrier.
 var Delegator delegatorType
 
-func (t *tracerImpl) Inject(sp opentracing.Span, format interface{}, carrier interface{}) error {
+func (t *tracerImpl) Inject(sc opentracing.SpanContext, format interface{}, carrier interface{}) error {
 	switch format {
 	case opentracing.TextMap:
-		return t.textPropagator.Inject(sp, carrier)
+		return t.textPropagator.Inject(sc, carrier)
 	case opentracing.Binary:
-		return t.binaryPropagator.Inject(sp, carrier)
+		return t.binaryPropagator.Inject(sc, carrier)
 	}
 	if _, ok := format.(delegatorType); ok {
-		return t.accessorPropagator.Inject(sp, carrier)
+		return t.accessorPropagator.Inject(sc, carrier)
 	}
 	return opentracing.ErrUnsupportedFormat
 }
 
-func (t *tracerImpl) Join(operationName string, format interface{}, carrier interface{}) (opentracing.Span, error) {
+func (t *tracerImpl) Extract(format interface{}, carrier interface{}) (opentracing.SpanContext, error) {
 	switch format {
 	case opentracing.TextMap:
-		return t.textPropagator.Join(operationName, carrier)
+		return t.textPropagator.Extract(carrier)
 	case opentracing.Binary:
-		return t.binaryPropagator.Join(operationName, carrier)
+		return t.binaryPropagator.Extract(carrier)
 	}
 	if _, ok := format.(delegatorType); ok {
-		return t.accessorPropagator.Join(operationName, carrier)
+		return t.accessorPropagator.Extract(carrier)
 	}
 	return nil, opentracing.ErrUnsupportedFormat
 }

--- a/tracer.go
+++ b/tracer.go
@@ -133,7 +133,11 @@ func (t *tracerImpl) getSpan() *spanImpl {
 		sp.reset()
 		return sp
 	}
-	return &spanImpl{}
+	return &spanImpl{
+		raw: RawSpan{
+			SpanContext: &SpanContext{},
+		},
+	}
 }
 
 func (t *tracerImpl) StartSpanWithOptions(


### PR DESCRIPTION
See https://github.com/opentracing/opentracing-go/pull/82 .

This change is included to show some of the ramifications of `SpanContext` for implementations and OT callers (via the examples and tests here). I'll add a few notes inline.

Benchmark diffs:

```
bhs@bhs-personal:~/git/lightstep/go/src$ ../bin/benchcmp /tmp/before /tmp/after
benchmark                                                    old ns/op     new ns/op     delta
BenchmarkSpan_Empty-8                                        629           632           +0.48%
BenchmarkSpan_100Events-8                                    35847         35271         -1.61%
BenchmarkSpan_1000Events-8                                   35587         35173         -1.16%
BenchmarkSpan_100Tags-8                                      43618         44145         +1.21%
BenchmarkSpan_1000Tags-8                                     44063         43838         -0.51%
BenchmarkSpan_100BaggageItems-8                              145397        32579         -77.59%
BenchmarkTrimmedSpan_100Events_100Tags_100BaggageItems-8     168957        79144         -53.16%
BenchmarkInject_TextMap_Empty-8                              2221          2292          +3.20%
BenchmarkInject_TextMap_100BaggageItems-8                    85977         87857         +2.19%
BenchmarkInject_Binary_Empty-8                               388           390           +0.52%
BenchmarkInject_Binary_100BaggageItems-8                     17861         18968         +6.20%
BenchmarkJoin_TextMap_Empty-8                                2849          2872          +0.81%
BenchmarkJoin_TextMap_100BaggageItems-8                      148235        146900        -0.90%
BenchmarkJoin_Binary_Empty-8                                 1175          1231          +4.77%
BenchmarkJoin_Binary_100BaggageItems-8                       37424         37700         +0.74%
```

I made these changes pretty casually and wonder if the huge improvements on the BaggageItems benchmarks are due to some sort of measurement error in the test itself (i.e., an invalid result).