### PR TITLE
Add a tracer option to make event logging operations no-ops.

### DIFF
--- a/span.go
+++ b/span.go
@@ -64,8 +64,7 @@ func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
 }
 
 func (s *spanImpl) trim() bool {
-	return s.tracer.options.TrimSpans ||
-		(!s.raw.Sampled && s.tracer.options.TrimUnsampledSpans)
+	return !s.raw.Sampled && s.tracer.options.TrimUnsampledSpans
 }
 
 func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {
@@ -106,7 +105,7 @@ func (s *spanImpl) Log(ld opentracing.LogData) {
 	defer s.onLog(ld)
 	s.Lock()
 	defer s.Unlock()
-	if s.trim() {
+	if s.trim() || s.tracer.options.DropAllLogs {
 		return
 	}
 

--- a/span.go
+++ b/span.go
@@ -64,7 +64,8 @@ func (s *spanImpl) SetOperationName(operationName string) opentracing.Span {
 }
 
 func (s *spanImpl) trim() bool {
-	return !s.raw.Sampled && s.tracer.options.TrimUnsampledSpans
+	return s.tracer.options.TrimSpans ||
+		(!s.raw.Sampled && s.tracer.options.TrimUnsampledSpans)
 }
 
 func (s *spanImpl) SetTag(key string, value interface{}) opentracing.Span {

--- a/span_test.go
+++ b/span_test.go
@@ -3,6 +3,7 @@ package basictracer
 import (
 	"testing"
 
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
 )
@@ -75,4 +76,77 @@ func TestSpan_Sampling(t *testing.T) {
 	ext.SamplingPriority.Set(span, 1)
 	span.Finish()
 	assert.Equal(t, 1, len(recorder.GetSampledSpans()), "SamplingPriority=1 should turn on sampling")
+}
+
+// Currently only logs and user-added tags are trimmed (i.e. not baggage)
+func TestSpan_Trimming(t *testing.T) {
+	recorder := NewInMemoryRecorder()
+	// Tracer that never trims
+	tracer := NewWithOptions(Options{
+		Recorder:     recorder,
+		ShouldSample: func(traceID uint64) bool { return true }, // always sample
+	})
+	span := tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans := recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, 1, len(spans[0].Logs))
+	assert.Equal(t, "event", spans[0].Logs[0].Event)
+	assert.Equal(t, "payload", spans[0].Logs[0].Payload)
+	assert.Equal(t, opentracing.Tags{"tag": "value"}, spans[0].Tags)
+
+	recorder.Reset()
+	// Tracer that trims only unsampled but always samples
+	tracer = NewWithOptions(Options{
+		Recorder:           recorder,
+		ShouldSample:       func(traceID uint64) bool { return true }, // always sample
+		TrimUnsampledSpans: true,
+	})
+
+	span = tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans = recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, 1, len(spans[0].Logs))
+	assert.Equal(t, "event", spans[0].Logs[0].Event)
+	assert.Equal(t, "payload", spans[0].Logs[0].Payload)
+	assert.Equal(t, opentracing.Tags{"tag": "value"}, spans[0].Tags)
+
+	recorder.Reset()
+	// Tracer that trims only unsampled and never samples
+	tracer = NewWithOptions(Options{
+		Recorder:           recorder,
+		ShouldSample:       func(traceID uint64) bool { return false }, // never sample
+		TrimUnsampledSpans: true,
+	})
+
+	span = tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans = recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, 0, len(spans[0].Logs))
+	assert.Equal(t, 0, len(spans[0].Tags))
+
+	recorder.Reset()
+	// Tracer that always trims and always samples
+	tracer = NewWithOptions(Options{
+		Recorder:     recorder,
+		ShouldSample: func(traceID uint64) bool { return true }, // always sample
+		TrimSpans:    true,
+	})
+
+	span = tracer.StartSpan("x")
+	span.LogEventWithPayload("event", "payload")
+	span.SetTag("tag", "value")
+	span.Finish()
+	spans = recorder.GetSpans()
+	assert.Equal(t, 1, len(spans))
+	assert.Equal(t, 0, len(spans[0].Logs))
+	assert.Equal(t, 0, len(spans[0].Tags))
 }

--- a/tracer.go
+++ b/tracer.go
@@ -27,10 +27,11 @@ type Options struct {
 	//
 	// samples every 64th trace on average.
 	ShouldSample func(traceID uint64) bool
-	// TrimUnsampledSpans turns potentially expensive operations on unsampled
-	// Spans into no-ops. More precisely, tags, baggage items, and log events
-	// are silently discarded. If NewSpanEventListener is set, the callbacks
-	// will still fire in that case.
+	// TrimSpans turns potentially expensive operations on Spans into no-ops.
+	// More precisely, tags, baggage items, and log events are silently discarded.
+	// If NewSpanEventListener is set, the callbacks will still fire in that case.
+	TrimSpans bool
+	// TrimUnsampledSpans is like TrimSpans, but only for unsampled Spans.
 	TrimUnsampledSpans bool
 	// Recorder receives Spans which have been finished.
 	Recorder SpanRecorder

--- a/tracer.go
+++ b/tracer.go
@@ -27,11 +27,9 @@ type Options struct {
 	//
 	// samples every 64th trace on average.
 	ShouldSample func(traceID uint64) bool
-	// TrimSpans turns potentially expensive operations on Spans into no-ops.
-	// More precisely, tags, baggage items, and log events are silently discarded.
-	// If NewSpanEventListener is set, the callbacks will still fire in that case.
-	TrimSpans bool
-	// TrimUnsampledSpans is like TrimSpans, but only for unsampled Spans.
+	// TrimUnsampledSpans turns potentially expensive operations on unsampled
+	// Spans into no-ops. More precisely, tags and log events are silently
+	// discarded. If NewSpanEventListener is set, the callbacks will still fire.
 	TrimUnsampledSpans bool
 	// Recorder receives Spans which have been finished.
 	Recorder SpanRecorder
@@ -39,6 +37,9 @@ type Options struct {
 	// attaching external code to trace events. See NetTraceIntegrator for a
 	// practical example, and event.go for the list of possible events.
 	NewSpanEventListener func() func(SpanEvent)
+	// DropAllLogs turns log events on all Spans into no-ops.
+	// If NewSpanEventListener is set, the callbacks will still fire.
+	DropAllLogs bool
 	// DebugAssertSingleGoroutine internally records the ID of the goroutine
 	// creating each Span and verifies that no operation is carried out on
 	// it on a different goroutine.


### PR DESCRIPTION
@bensigelman 

This allows tracers to turn off logging, which can be potentially much more expensive than timing data and tags.