### PR TITLE
event: update NetTraceIntegrator to support LogFields, Tag

### DIFF
--- a/events/event_nettrace.go
+++ b/events/event_nettrace.go
@@ -1,8 +1,12 @@
 package events
 
 import (
-	"github.com/opentracing/basictracer-go"
+	"bytes"
+	"fmt"
+
 	"golang.org/x/net/trace"
+
+	basictracer "github.com/opentracing/basictracer-go"
 )
 
 // NetTraceIntegrator can be passed into a basictracer as NewSpanEventListener
@@ -16,6 +20,18 @@ var NetTraceIntegrator = func() func(basictracer.SpanEvent) {
 			tr.SetMaxEvents(1000)
 		case basictracer.EventFinish:
 			tr.Finish()
+		case basictracer.EventTag:
+			tr.LazyPrintf("%s:%v", t.Key, t.Value)
+		case basictracer.EventLogFields:
+			var buf bytes.Buffer
+			for i, f := range t.Fields {
+				if i > 0 {
+					buf.WriteByte(' ')
+				}
+				fmt.Fprintf(&buf, "%s:%v", f.Key(), f.Value())
+			}
+
+			tr.LazyPrintf("%s", buf.String())
 		case basictracer.EventLog:
 			if t.Payload != nil {
 				tr.LazyPrintf("%s (payload %v)", t.Event, t.Payload)


### PR DESCRIPTION
`NetTraceIntegrator` now handles `EventLogFields` and `EventTag` and produces
messages for them.

I used my best judgment for how to convert KV fields to a single message but I am kind of pulling it out of a hat.  Ideally it would be consistent with how Lighstep will do it; @bensigelman are there any thoughts/plans on that front?

@tschottdorf @petermattis