### PR TITLE
Improve the "use-after-free" assertion

### DIFF
--- a/span.go
+++ b/span.go
@@ -171,7 +171,9 @@ func (s *spanImpl) FinishWithOptions(opts opentracing.FinishOptions) {
 	if s.tracer.options.DebugAssertUseAfterFinish {
 		// This makes it much more likely to catch a panic on any subsequent
 		// operation since s.tracer is accessed on every call to `Lock`.
-		s.reset()
+		// We don't call `reset()` here to preserve the logs in the Span
+		// which are printed when the assertion triggers.
+		s.tracer = nil
 	}
 
 	if poolEnabled {


### PR DESCRIPTION
Let it print out the "previous" contents of the Span when it triggers
a use-after-free assertion. This is valuable in tracking down the past
of that Span, and thus the original call to Finish().