### PR TITLE
Test relevant Go versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: go
 
 go:
   - 1.5
+  - 1.6
+  - 1.7.1
   - tip
 
 install:


### PR DESCRIPTION
Testing 1.5 and tip only seems awkward at this point.