### PR TITLE
add MultiRecorder

### DIFF
--- a/recorder.go
+++ b/recorder.go
@@ -58,3 +58,18 @@ func (r *InMemorySpanRecorder) Reset() {
 	defer r.Unlock()
 	r.spans = nil
 }
+
+type multiRecorder []SpanRecorder
+
+func (mr multiRecorder) RecordSpan(span RawSpan) {
+	for _, r := range mr {
+		r.RecordSpan(span)
+	}
+}
+
+// MultiRecorder creates a recorder that duplicates its writes to all the provided recorders.
+func MultiRecorder(recorders ...SpanRecorder) SpanRecorder {
+	mr := make(multiRecorder, len(recorders))
+	copy(mr, recorders)
+	return mr
+}

--- a/recorder_test.go
+++ b/recorder_test.go
@@ -22,6 +22,21 @@ func TestInMemoryRecorderSpans(t *testing.T) {
 	assert.Equal(t, []RawSpan{}, recorder.GetSampledSpans())
 }
 
+func TestMultiRecorder(t *testing.T) {
+	r1 := NewInMemoryRecorder()
+	r2 := NewInMemoryRecorder()
+	mr := MultiRecorder(r1, r2)
+	span := RawSpan{
+		Context:   SpanContext{},
+		Operation: "test-span",
+		Start:     time.Now(),
+		Duration:  -1,
+	}
+	mr.RecordSpan(span)
+	assert.Equal(t, []RawSpan{span}, r1.GetSpans())
+	assert.Equal(t, []RawSpan{span}, r2.GetSpans())
+}
+
 type CountingRecorder int32
 
 func (c *CountingRecorder) RecordSpan(r RawSpan) {


### PR DESCRIPTION
This new function is similar to `io.MultiWriter` and is useful for writing to multiple opentracing backends at the same time.