### PR TITLE
Add tests from API check suite

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -1,0 +1,24 @@
+package basictracer
+
+import (
+	"testing"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/harness"
+	"github.com/stretchr/testify/suite"
+)
+
+func TestAPICheck(t *testing.T) {
+	apiSuite := harness.NewAPICheckSuite(func() (tracer opentracing.Tracer, closer func()) {
+		tracer = NewWithOptions(Options{
+			Recorder:     NewInMemoryRecorder(),
+			ShouldSample: func(traceID uint64) bool { return true }, // always sample
+		})
+		return tracer, nil
+	}, harness.APICheckCapabilities{
+		CheckBaggageValues: true,
+		CheckInject:        true,
+		CheckExtract:       true,
+	})
+	suite.Run(t, apiSuite)
+}

--- a/api_test.go
+++ b/api_test.go
@@ -3,13 +3,13 @@ package basictracer
 import (
 	"testing"
 
-	opentracing "github.com/opentracing/opentracing-go"
+	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/harness"
 	"github.com/stretchr/testify/suite"
 )
 
 func TestAPICheck(t *testing.T) {
-	apiSuite := harness.NewAPICheckSuite(func() (tracer opentracing.Tracer, closer func()) {
+	apiSuite := harness.NewAPICheckSuite(func() (tracer ot.Tracer, closer func()) {
 		tracer = NewWithOptions(Options{
 			Recorder:     NewInMemoryRecorder(),
 			ShouldSample: func(traceID uint64) bool { return true }, // always sample
@@ -19,6 +19,36 @@ func TestAPICheck(t *testing.T) {
 		CheckBaggageValues: true,
 		CheckInject:        true,
 		CheckExtract:       true,
+		Probe:              apiCheckProbe{},
 	})
 	suite.Run(t, apiSuite)
+}
+
+// implements harness.APICheckProbe
+type apiCheckProbe struct{}
+
+// SameTrace helps tests assert that this tracer's spans are from the same trace.
+func (apiCheckProbe) SameTrace(first, second ot.Span) bool {
+	span1, ok := first.(*spanImpl)
+	if !ok { // some other tracer's span
+		return false
+	}
+	span2, ok := second.(*spanImpl)
+	if !ok { // some other tracer's span
+		return false
+	}
+	return span1.raw.Context.TraceID == span2.raw.Context.TraceID
+}
+
+// SameTraceContext helps tests assert that a span and a span context are from the same trace.
+func (apiCheckProbe) SameTraceContext(span ot.Span, spanContext ot.SpanContext) bool {
+	sp, ok := span.(*spanImpl)
+	if !ok {
+		return false
+	}
+	ctx, ok := spanContext.(SpanContext)
+	if !ok {
+		return false
+	}
+	return sp.raw.Context.TraceID == ctx.TraceID
 }

--- a/api_test.go
+++ b/api_test.go
@@ -5,7 +5,6 @@ import (
 
 	ot "github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/harness"
-	"github.com/stretchr/testify/suite"
 )
 
 // newTracer creates a new tracer for each test, and returns a nil cleanup function.
@@ -18,12 +17,11 @@ func newTracer() (tracer ot.Tracer, closer func()) {
 }
 
 func TestAPICheck(t *testing.T) {
-	apiSuite := harness.NewAPICheckSuite(
+	harness.RunAPIChecks(t,
 		newTracer,
-		harness.CheckEverything{},
-		harness.UseProbe{apiCheckProbe{}},
+		harness.CheckEverything(),
+		harness.UseProbe(apiCheckProbe{}),
 	)
-	suite.Run(t, apiSuite)
 }
 
 // implements harness.APICheckProbe


### PR DESCRIPTION
This adds a suite of Tracer API compatibility checks from (from opentracing/opentracing-go#146) to basictracer-go.